### PR TITLE
channel: fix use after delete

### DIFF
--- a/runtime/channel.cc
+++ b/runtime/channel.cc
@@ -1471,9 +1471,10 @@ namespace LegionRuntime {
                 break;
             }
             while(!finish_xferdes.empty()) {
-              delete finish_xferdes.back();
-              it->second->erase(finish_xferdes.back());
+              XferDes *xd = finish_xferdes.back();
               finish_xferdes.pop_back();
+              it->second->erase(xd);
+              delete xd;
             }
           }
         }


### PR DESCRIPTION
The comparator references `XferDes.priority` during `erase` so it should
be deleted after erasure.

Signed-off-by: Noah Watkins <noahwatkins@gmail.com>