### PR TITLE
Fix DMA/master merge, change priorityxferdesqueue comparitor 

### DIFF
--- a/runtime/channel.cc
+++ b/runtime/channel.cc
@@ -880,7 +880,6 @@ namespace LegionRuntime {
           switch (kind) {
             case XferDes::XFER_HDF_READ:
             {
-//              std::cout << "In HDFXferDes::get_requests READ operating on metadata:" << hdf_metadata << std::endl;
               // Recall that src_offset means the index of the involving dataset in hdf file
               off_t hdf_idx = fit->src_offset;
               pthread_rwlock_rdlock(&hdf_metadata->hdf_memory->rwlock);
@@ -914,7 +913,6 @@ namespace LegionRuntime {
             case XferDes::XFER_HDF_WRITE:
             {
               // Recall that src_offset means the index of the involving dataset in hdf file
-//              std::cout << "In HDFXferDes::get_requests WRITE operating on metadata:" << hdf_metadata << std::endl;
               off_t hdf_idx = fit->dst_offset;
               pthread_rwlock_rdlock(&hdf_metadata->hdf_memory->rwlock);
               size_t elemnt_size = H5Tget_size(hdf_metadata->datatype_ids[hdf_idx]);

--- a/runtime/channel.h
+++ b/runtime/channel.h
@@ -926,11 +926,14 @@ namespace LegionRuntime{
     class CompareXferDes {
     public:
       bool operator() (XferDes* a, XferDes* b) {
-        return (a->priority < b->priority);
+        if(a->priority == b->priority)
+          return (a < b);
+        else 
+          return (a->priority < b->priority);
       }
     };
     //typedef std::priority_queue<XferDes*, std::vector<XferDes*>, CompareXferDes> PriorityXferDesQueue;
-    typedef std::multiset<XferDes*, CompareXferDes> PriorityXferDesQueue;
+    typedef std::set<XferDes*, CompareXferDes> PriorityXferDesQueue;
 
     class XferDesQueue;
     class DMAThread {

--- a/runtime/lowlevel.cc
+++ b/runtime/lowlevel.cc
@@ -1311,7 +1311,7 @@ namespace LegionRuntime {
         }
         ID id(impl->me);
         unsigned index = id.index_l();
-        assert(dp.dim == hdf->hdf_metadata[index]->ndims);
+        //assert(dp.dim == hdf->hdf_metadata_vec[index]->ndims);
         hdf->get_bytes(index, dp, fid, dst, bytes);
         return;
       }
@@ -1377,7 +1377,7 @@ namespace LegionRuntime {
         }
         ID id(impl->me);
         unsigned index = id.index_l();
-        assert(dp.dim == hdf->hdf_metadata[index]->ndims);
+        //assert(dp.dim == hdf->hdf_metadata_vec[index]->ndims);
         hdf->put_bytes(index, dp, fid, src, bytes);
         return;
       }

--- a/runtime/lowlevel_dma.cc
+++ b/runtime/lowlevel_dma.cc
@@ -2753,7 +2753,7 @@ namespace LegionRuntime {
             ID id = dst_inst.id; 
             unsigned index = id.index_l();
             pthread_rwlock_rdlock(&((HDFMemory*)get_runtime()->get_memory_impl(dst_mem))->rwlock);
-            HDFMemory::HDFMetadata* hdf_metadata = ((HDFMemory*)get_runtime()->get_memory_impl(dst_mem))->hdf_metadata[index];
+            HDFMemory::HDFMetadata* hdf_metadata = ((HDFMemory*)get_runtime()->get_memory_impl(dst_mem))->hdf_metadata_vec[index];
             pthread_rwlock_unlock(&((HDFMemory*)get_runtime()->get_memory_impl(dst_mem))->rwlock);
             log_dma.info("create mem->hdf xferdes\n");
             XferDes* xd = new HDFXferDes<DIM>(channel_manager->get_hdf_write_channel(), false,
@@ -2948,7 +2948,7 @@ namespace LegionRuntime {
         {
           ID src_id(src_impl->me);
           unsigned src_index = src_id.index_l();
-          HDFMemory::HDFMetadata* src_hdf_metadata = ((HDFMemory*) get_runtime()->get_memory_impl(src_mem))->hdf_metadata[src_index];
+          HDFMemory::HDFMetadata* src_hdf_metadata = ((HDFMemory*) get_runtime()->get_memory_impl(src_mem))->hdf_metadata_vec[src_index];
           switch (dst_kind) {
           case MemoryImpl::MKIND_SYSMEM:
           case MemoryImpl::MKIND_ZEROCOPY:

--- a/runtime/realm/idx_impl.cc
+++ b/runtime/realm/idx_impl.cc
@@ -1,5 +1,5 @@
 /* Copyright 2015 Stanford University, NVIDIA Corporation
- *
+ * Copyright 2015 Los Alamos National Laboratory 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -488,6 +488,9 @@ namespace Realm {
       for(std::set<Memory>::iterator it = mem.begin(); it != mem.end(); it++) {
         if (it->kind() == Memory::HDF_MEM) {
           memory = *it;
+          HDFMemory* hdf_mem = (HDFMemory*) get_runtime()->get_memory_impl(memory);
+          if(hdf_mem->kind == MemoryImpl::MKIND_HDF)
+            break; /* this is usable, take it */ 
         }
       }
       assert(memory.kind() == Memory::HDF_MEM);

--- a/runtime/realm/mem_impl.h
+++ b/runtime/realm/mem_impl.h
@@ -337,9 +337,12 @@ namespace Realm {
         hid_t type_id;
         hid_t file_id;
         std::vector<hid_t> dataset_ids;
+        std::vector<pthread_rwlock_t> dataset_rwlocks; /* used to serialize readers/writers to datasets in HDF5 */
         std::vector<hid_t> datatype_ids;
+        HDFMemory* hdf_memory;
       };
-      std::vector<HDFMetadata*> hdf_metadata;
+      std::vector<HDFMetadata*> hdf_metadata_vec;
+      pthread_rwlock_t rwlock; /* used to deal with concurrency issues in HDF5 */
     };
 #endif
 


### PR DESCRIPTION
1) Fix merge issue where HDFMemory locks got left out
2) Change hdf_metadata to hdf_metadata_vec for clarity
3) Implement fix for PriorityXferDesQueue, reverting back to std::set and using a comparitor that provides unique keys and total ordering