### PR TITLE
Added missing cudart to thrust_interop Makefile

### DIFF
--- a/examples/thrust_interop/Makefile
+++ b/examples/thrust_interop/Makefile
@@ -37,12 +37,12 @@ INC_FLAGS	:=
 CC_FLAGS	?=
 NVCC_FLAGS	:=
 GASNET_FLAGS	:=
-LD_FLAGS	:=
+LD_FLAGS	:= -lcudart
 
 ###########################################################################
 #
 #   Don't change anything below here
-#   
+#
 ###########################################################################
 
 include $(LG_RT_DIR)/runtime.mk


### PR DESCRIPTION
resolves several linker errors (undefined reference to `cudaStreamWaitEvent') when compiling thrust_interop example.