### PR TITLE
Change clean rule to have double ::

### DIFF
--- a/runtime/runtime.mk
+++ b/runtime/runtime.mk
@@ -413,7 +413,7 @@ $(GEN_GPU_OBJS) : %.o : %.cu
 $(GPU_RUNTIME_OBJS): %.o : %.cu
 	$(NVCC) -o $@ -c $< $(NVCC_FLAGS) $(INC_FLAGS)
 
-clean:
+clean::
 	$(RM) -f $(OUTFILE) $(SLIB_LEGION) $(SLIB_REALM) $(SLIB_SHAREDLLR) $(GEN_OBJS) $(GEN_GPU_OBJS) $(LOW_RUNTIME_OBJS) $(HIGH_RUNTIME_OBJS) $(GPU_RUNTIME_OBJS) $(MAPPER_OBJS) $(ASM_OBJS)
 
 endif


### PR DESCRIPTION
If the clean rule is changed from clean: to clean::, then users can add a clean:: rule to their projects to clean up additional files that are not cleaned by the default legion clean rule.  

An example would be cleaning up test result output.