### PR TITLE
Permit application makefile to override USE_LIBDL

### DIFF
--- a/runtime/runtime.mk
+++ b/runtime/runtime.mk
@@ -126,13 +126,13 @@ ifeq ($(strip $(USE_HWLOC)),1)
   LEGION_LD_FLAGS += -L$(HWLOC)/lib -lhwloc
 endif
 
-USE_LIBDL = 1
+USE_LIBDL ?= 1
 ifeq ($(strip $(USE_LIBDL)),1)
 #CC_FLAGS += -rdynamic
 LEGION_LD_FLAGS += -ldl -rdynamic
 endif
 
-# Falgs for running in the general low-level runtime
+# Flags for running in the general low-level runtime
 ifeq ($(strip $(SHARED_LOWLEVEL)),0)
 
 # general low-level uses CUDA by default


### PR DESCRIPTION
The USE_LIBDL option was not using the conditional variable assignment (?=) which most/all other options in the runtime.mk are using.

Also fix spelling error in comment