### PR TITLE
Fix so can compile -DNDEBUG without unused variable warnings

### DIFF
--- a/runtime/accessor.h
+++ b/runtime/accessor.h
@@ -384,7 +384,10 @@ namespace LegionRuntime {
 	    //printf("in soa(%zd) converter\n", STRIDE);
 	    void *soa_base = 0;
 	    size_t soa_stride = STRIDE;
-	    bool ok = get_soa_parameters(soa_base, soa_stride);
+#ifndef NDEBUG
+	    bool ok =
+#endif
+	      get_soa_parameters(soa_base, soa_stride);
 	    assert(ok);
 	    typename AT::template Typed<T, T> t(soa_base, soa_stride);
             RegionAccessor<AT,T> result(t);
@@ -416,7 +419,10 @@ namespace LegionRuntime {
 	    size_t hybrid_soa_stride = STRIDE;
 	    size_t hybrid_soa_block_size = BLOCK_SIZE;
 	    size_t hybrid_soa_block_stride = BLOCK_STRIDE;
-	    bool ok = get_hybrid_soa_parameters(hybrid_soa_base, hybrid_soa_stride,
+#ifndef NDEBUG
+	    bool ok =
+#endif
+	      get_hybrid_soa_parameters(hybrid_soa_base, hybrid_soa_stride,
 						hybrid_soa_block_size, hybrid_soa_block_stride);
 	    assert(ok);
 	    typename AT::template Typed<T, T> t(hybrid_soa_base, hybrid_soa_stride,
@@ -441,7 +447,10 @@ namespace LegionRuntime {
 	  template <typename AT, typename REDOP>
 	  RegionAccessor<AT, T> convert_helper(ReductionFold<REDOP> *dummy) const {
 	    void *redfold_base = 0;
-	    bool ok = get_redfold_parameters(redfold_base);
+#ifndef NDEBUG
+	    bool ok =
+#endif
+	      get_redfold_parameters(redfold_base);
 	    assert(ok);
 	    typename AT::template Typed<T, T> t(redfold_base);
             RegionAccessor<AT, T> result(t);
@@ -466,7 +475,10 @@ namespace LegionRuntime {
 	  RegionAccessor<AT, T> convert_helper(ReductionList<REDOP> *dummy) const {
 	    void *redlist_base = 0;
 	    ptr_t *redlist_next_ptr = 0;
-	    bool ok = get_redlist_parameters(redlist_base, redlist_next_ptr);
+#ifndef NDEBUG
+	    bool ok =
+#endif
+	      get_redlist_parameters(redlist_base, redlist_next_ptr);
 	    assert(ok);
 	    typename AT::template Typed<T, T> t(redlist_base, redlist_next_ptr);
             RegionAccessor<AT, T> result(t);

--- a/runtime/legion/legion_ops.cc
+++ b/runtime/legion/legion_ops.cc
@@ -6214,7 +6214,9 @@ namespace LegionRuntime {
       const size_t result_size = redop->sizeof_lhs;
       void *result_buffer = legion_malloc(FUTURE_RESULT_ALLOC, result_size);
 #ifdef DEBUG_HIGH_LEVEL
+#ifndef NDEBUG
       bool result = 
+#endif
 #endif
       collective.phase_barrier.get_previous_phase().get_result(result_buffer,
 							       result_size);

--- a/runtime/legion/legion_tasks.cc
+++ b/runtime/legion/legion_tasks.cc
@@ -4342,7 +4342,9 @@ namespace LegionRuntime {
               if (perform_mapping())
               {
 #ifdef DEBUG_HIGH_LEVEL
+#ifndef NDEBUG
                 bool still_local = 
+#endif
 #endif
                 distribute_task();
 #ifdef DEBUG_HIGH_LEVEL
@@ -5941,7 +5943,9 @@ namespace LegionRuntime {
                   if (perform_mapping())
                   {
 #ifdef DEBUG_HIGH_LEVEL
+#ifndef NDEBUG
                     bool still_local = 
+#endif
 #endif
                     distribute_task();
 #ifdef DEBUG_HIGH_LEVEL

--- a/runtime/legion/legion_utilities.h
+++ b/runtime/legion/legion_utilities.h
@@ -1606,7 +1606,9 @@ namespace LegionRuntime {
     {
 #ifdef DEBUG_HIGH_LEVEL
       // Save our enclosing context on the stack
+#ifndef NDEBUG
       size_t sent_context = *((const size_t*)(buffer+index));
+#endif
       index += sizeof(size_t);
       // Check to make sure that they match
       assert(sent_context == context_bytes);
@@ -1620,7 +1622,9 @@ namespace LegionRuntime {
     {
 #ifdef DEBUG_HIGH_LEVEL
       // Read the send context size out of the buffer      
+#ifndef NDEBUG
       size_t sent_context = *((const size_t*)(buffer+index));
+#endif
       index += sizeof(size_t);
       // Check to make sure that they match
       assert(sent_context == context_bytes);

--- a/runtime/legion/region_tree.cc
+++ b/runtime/legion/region_tree.cc
@@ -2073,7 +2073,9 @@ namespace LegionRuntime {
         // First compute the path
         std::vector<ColorPoint> path;
 #ifdef DEBUG_HIGH_LEVEL
+#ifndef NDEBUG
         bool result = 
+#endif
 #endif
         compute_index_path(inst_manager->region_node->row_source->handle,
                            top_node->row_source->handle, path);
@@ -11915,7 +11917,9 @@ namespace LegionRuntime {
       bool create_composite = false;
       std::set<ColorPoint> empty_next_children;
 #ifdef DEBUG_HIGH_LEVEL
+#ifndef NDEBUG
       bool result = 
+#endif
 #endif
       siphon_physical_children(next_closer, state, closing_mask,
                                empty_next_children, create_composite);
@@ -14983,7 +14987,9 @@ namespace LegionRuntime {
             bool create_composite = false;
             std::set<ColorPoint> empty_next_children;
 #ifdef DEBUG_HIGH_LEVEL
+#ifndef NDEBUG
             bool result = 
+#endif
 #endif
             siphon_physical_children(closer, state, user_mask,
                                      empty_next_children, 

--- a/runtime/legion/runtime.cc
+++ b/runtime/legion/runtime.cc
@@ -977,6 +977,7 @@ namespace LegionRuntime {
     //--------------------------------------------------------------------------
     {
 #ifdef DEBUG_HIGH_LEVEL
+#ifndef NDEBUG
       // Check to make sure we are asking for something in the domain
       if (valid_points.find(point) == valid_points.end())
       {
@@ -992,6 +993,7 @@ namespace LegionRuntime {
         }
         assert(is_valid_point);
       }
+#endif
 #endif
       if (valid)
       {
@@ -13589,7 +13591,9 @@ namespace LegionRuntime {
     //--------------------------------------------------------------------------
     {
 #ifdef DEBUG_HIGH_LEVEL
+#ifndef NDEBUG
       unsigned previous = 
+#endif
 #endif
       __sync_fetch_and_add(&outstanding_top_level_tasks,1);
 #ifdef DEBUG_HIGH_LEVEL
@@ -15775,7 +15779,9 @@ namespace LegionRuntime {
       if (uid == AUTO_GENERATE_ID)
       {
 #ifdef DEBUG_HIGH_LEVEL
+#ifndef NDEBUG
         bool found = false; 
+#endif
 #endif
         for (unsigned idx = 0; idx < uid; idx++)
         {
@@ -15783,7 +15789,9 @@ namespace LegionRuntime {
           {
             uid = idx;
 #ifdef DEBUG_HIGH_LEVEL
+#ifndef NDEBUG
             found = true;
+#endif
 #endif
             break;
           }

--- a/runtime/lowlevel.cc
+++ b/runtime/lowlevel.cc
@@ -1497,7 +1497,10 @@ namespace LegionRuntime {
 
       void *base;
       size_t act_stride = 0;
-      bool ok = impl->get_strided_parameters(base, act_stride, field_offset);
+#ifndef NDEBUG
+      bool ok =
+#endif
+	impl->get_strided_parameters(base, act_stride, field_offset);
       assert(ok);
 
 #ifdef BOUNDS_CHECKS

--- a/runtime/lowlevel_disk.cc
+++ b/runtime/lowlevel_disk.cc
@@ -79,14 +79,20 @@ namespace Realm {
     void DiskMemory::get_bytes(off_t offset, void *dst, size_t size)
     {
       // this is a blocking operation
-      ssize_t amt = pread(fd, dst, size, offset);
+#ifndef NDEBUG
+      ssize_t amt =
+#endif
+	pread(fd, dst, size, offset);
       assert(amt == (ssize_t)size);
     }
 
     void DiskMemory::put_bytes(off_t offset, const void *src, size_t size)
     {
       // this is a blocking operation
-      ssize_t amt = pwrite(fd, src, size, offset);
+#ifndef NDEBUG
+      ssize_t amt =
+#endif
+	pwrite(fd, src, size, offset);
       assert(amt == (ssize_t)size);
     }
 
@@ -180,7 +186,10 @@ namespace Realm {
           for(std::vector<size_t>::const_iterator it = field_sizes.begin(); it != field_sizes.end(); it++) {
             field_size += *it;
           }
-          int ret = ftruncate(fd, field_size * domain.get_volume());
+#ifndef NDEBUG
+          int ret =
+#endif
+	    ftruncate(fd, field_size * domain.get_volume());
           assert(ret == 0);
           break;
         }
@@ -235,7 +244,10 @@ namespace Realm {
       pthread_mutex_lock(&vector_lock);
       int fd = file_vec[inst_id];
       pthread_mutex_unlock(&vector_lock);
-      size_t ret = pread(fd, dst, size, offset);
+#ifndef NDEBUG
+      size_t ret =
+#endif
+	pread(fd, dst, size, offset);
       assert(ret == size);
     }
 
@@ -249,7 +261,10 @@ namespace Realm {
       pthread_mutex_lock(&vector_lock);
       int fd = file_vec[inst_id];
       pthread_mutex_unlock(&vector_lock);
-      size_t ret = pwrite(fd, src, size, offset);
+#ifndef NDEBUG
+      size_t ret =
+#endif
+	pwrite(fd, src, size, offset);
       assert(ret == size);
     }
 

--- a/runtime/lowlevel_dma.cc
+++ b/runtime/lowlevel_dma.cc
@@ -1910,7 +1910,10 @@ namespace LegionRuntime {
     void PosixAIOWrite::launch(void)
     {
       log_aio.debug("write issued: op=%p cb=%p", this, &cb);
-      int ret = aio_write(&cb);
+#ifndef NDEBUG
+      int ret =
+#endif
+	aio_write(&cb);
       assert(ret == 0);
     }
 
@@ -1948,7 +1951,10 @@ namespace LegionRuntime {
     void PosixAIORead::launch(void)
     {
       log_aio.debug("read issued: op=%p cb=%p", this, &cb);
-      int ret = aio_read(&cb);
+#ifndef NDEBUG
+      int ret =
+#endif
+	aio_read(&cb);
       assert(ret == 0);
     }
 
@@ -3555,7 +3561,10 @@ namespace LegionRuntime {
 	   (src_kind == MemoryImpl::MKIND_RDMA)) {
 	  void *src_base = 0;
 	  size_t src_stride = 0;
-	  bool src_ok = get_runtime()->get_instance_impl(srcs[0].inst)->get_strided_parameters(src_base, src_stride,
+#ifndef NDEBUG
+	  bool src_ok =
+#endif
+	    get_runtime()->get_instance_impl(srcs[0].inst)->get_strided_parameters(src_base, src_stride,
 											       srcs[0].offset);
 	  assert(src_ok);
 
@@ -3565,7 +3574,10 @@ namespace LegionRuntime {
 	    {
 	      void *dst_base = 0;
 	      size_t dst_stride = 0;
-	      bool dst_ok = get_runtime()->get_instance_impl(dst.inst)->get_strided_parameters(dst_base, dst_stride,
+#ifndef NDEBUG
+	      bool dst_ok =
+#endif
+		get_runtime()->get_instance_impl(dst.inst)->get_strided_parameters(dst_base, dst_stride,
 											       dst.offset);
 	      assert(dst_ok);
 
@@ -3597,8 +3609,8 @@ namespace LegionRuntime {
 
 	      assert(dst_impl->metadata.is_valid());
 
-	      off_t dst_field_start;
-	      int dst_field_size;
+	      off_t dst_field_start=0;
+	      int dst_field_size=0;
 	      find_field_start(dst_impl->metadata.field_sizes, dst.offset, dst.size, dst_field_start, dst_field_size);
 	      assert(dst.size == (size_t)dst_field_size);
 
@@ -3677,8 +3689,8 @@ namespace LegionRuntime {
 
 	      assert(dst_impl->metadata.is_valid());
 
-	      off_t dst_field_start;
-	      int dst_field_size;
+	      off_t dst_field_start=0;
+	      int dst_field_size=0;
 	      find_field_start(dst_impl->metadata.field_sizes, dst.offset, dst.size, dst_field_start, dst_field_size);
 	      assert(dst.size == (size_t)dst_field_size);
 
@@ -3961,7 +3973,7 @@ namespace LegionRuntime {
               IndexSpaceImpl *ispace = get_runtime()->get_index_space_impl(domain.get_index_space());
               assert(ispace->valid_mask_complete);
               RegionInstanceImpl *inst_impl = get_runtime()->get_instance_impl(dst.inst);
-              off_t field_start; int field_size;
+              off_t field_start=0; int field_size=0;
               find_field_start(inst_impl->metadata.field_sizes, dst.offset,
                                dst.size, field_start, field_size);
               assert(field_size <= int(fill_size));
@@ -4035,7 +4047,7 @@ namespace LegionRuntime {
     void FillRequest::perform_dma_rect(MemoryImpl *mem_impl)
     {
       RegionInstanceImpl *inst_impl = get_runtime()->get_instance_impl(dst.inst);
-      off_t field_start; int field_size;
+      off_t field_start=0; int field_size=0;
       find_field_start(inst_impl->metadata.field_sizes, dst.offset,
                        dst.size, field_start, field_size);
       assert(field_size <= (int)fill_size);

--- a/runtime/realm/dynamic_table.inl
+++ b/runtime/realm/dynamic_table.inl
@@ -241,7 +241,10 @@ namespace Realm {
       IT to_lookup = next_alloc;
       next_alloc += ((IT)1) << ALLOCATOR::LEAF_BITS; // do this before letting go of lock
       lock.unlock();
-      typename DynamicTable<ALLOCATOR>::ET *dummy = table.lookup_entry(to_lookup, owner, this);
+#ifndef NDEBUG
+      typename DynamicTable<ALLOCATOR>::ET *dummy =
+#endif
+        table.lookup_entry(to_lookup, owner, this);
       assert(dummy != 0);
       // can't actually use dummy because we let go of lock - retake lock and hopefully find non-empty
       //  list next time

--- a/runtime/realm/inst_impl.cc
+++ b/runtime/realm/inst_impl.cc
@@ -200,8 +200,8 @@ namespace Realm {
         offset += field_offset;
         elmt_stride = metadata.elmt_size;
       } else {
-        off_t field_start;
-        int field_size;
+        off_t field_start=0;
+        int field_size=0;
         find_field_start(metadata.field_sizes, field_offset, 1, field_start, field_size);
 
         offset += (field_start * metadata.block_size) + (field_offset - field_start);
@@ -350,8 +350,8 @@ namespace Realm {
 	// no blocking - don't need to know about field boundaries
 	o = metadata.alloc_offset + (index * metadata.elmt_size) + byte_offset;
       } else {
-	off_t field_start;
-	int field_size;
+	off_t field_start=0;
+	int field_size=0;
 	find_field_start(metadata.field_sizes, byte_offset, size, field_start, field_size);
         o = calc_mem_loc(metadata.alloc_offset, field_start, field_size,
                          metadata.elmt_size, metadata.block_size, index);
@@ -370,8 +370,8 @@ namespace Realm {
 	// no blocking - don't need to know about field boundaries
 	o = metadata.alloc_offset + (index * metadata.elmt_size) + byte_offset;
       } else {
-	off_t field_start;
-	int field_size;
+	off_t field_start=0;
+	int field_size=0;
 	find_field_start(metadata.field_sizes, byte_offset, size, field_start, field_size);
         o = calc_mem_loc(metadata.alloc_offset, field_start, field_size,
                          metadata.elmt_size, metadata.block_size, index);

--- a/runtime/realm/machine_impl.cc
+++ b/runtime/realm/machine_impl.cc
@@ -121,8 +121,9 @@ namespace Realm {
       AutoHSLLock al(mutex);
 
       const size_t *cur = (const size_t *)args;
+#ifndef NDEBUG
       const size_t *limit = (const size_t *)(((const char *)args)+arglen);
-
+#endif
       while(1) {
 	assert(cur < limit);
 	if(*cur == NODE_ANNOUNCE_DONE) break;

--- a/runtime/realm/profiling.inl
+++ b/runtime/realm/profiling.inl
@@ -163,7 +163,10 @@ namespace Realm {
 
     // serialize the data
     Serialization::DynamicBufferSerializer dbs(128);
-    bool ok = dbs << data;
+#ifndef NDEBUG
+    bool ok =
+#endif
+      dbs << data;
     assert(ok);
 
     // measurement data is stored in a ByteArray
@@ -223,7 +226,10 @@ namespace Realm {
     if(find_id((int)(T::ID), offset, size)) {
       Serialization::FixedBufferDeserializer fbd(data + offset, size);
       T *m = new T;
-      bool ok = fbd >> *m;
+#ifndef NDEBUG
+      bool ok =
+#endif
+        fbd >> *m;
       assert(ok);
       return m;
     } else

--- a/runtime/realm/rsrv_impl.cc
+++ b/runtime/realm/rsrv_impl.cc
@@ -451,7 +451,10 @@ namespace Realm {
 	impl->mode = args.mode;
 	impl->requested = false;
 
-	bool any_local = impl->select_local_waiters(to_wake);
+#ifndef NDEBUG
+	bool any_local =
+#endif
+	  impl->select_local_waiters(to_wake);
 	assert(any_local);
       }
 

--- a/runtime/realm/tasks.cc
+++ b/runtime/realm/tasks.cc
@@ -176,7 +176,9 @@ namespace Realm {
 
     // sanity-check: a wait value earlier than the number we just incremented
     //  from should not be possible
+#ifndef NDEBUG
     long long wv_check = __sync_fetch_and_add(&wait_value, 0);
+#endif
     assert((wv_check == -1) || (wv_check > old_value));
   }
 
@@ -217,7 +219,10 @@ namespace Realm {
       condvar.broadcast();
     }
     assert(wv_read <= old_counter);
-    bool ok = __sync_bool_compare_and_swap(&wait_value, wv_read, old_counter);
+#ifndef NDEBUG
+    bool ok =
+#endif
+      __sync_bool_compare_and_swap(&wait_value, wv_read, old_counter);
     assert(ok); // swap should never fail
 
     // now that people know we're waiting, wait until the counter updates - check before
@@ -481,7 +486,10 @@ namespace Realm {
 	  // release the lock while we run the task
 	  lock.unlock();
 
-	  bool ok = execute_task(task);
+#ifndef NDEBUG
+	  bool ok =
+#endif
+	    execute_task(task);
 	  assert(ok);  // no fault recovery yet
 
 	  lock.lock();
@@ -721,7 +729,10 @@ namespace Realm {
 #endif
 
     // take ourself off the active list
-    size_t count = active_workers.erase(Thread::self());
+#ifndef NDEBUG
+    size_t count =
+#endif
+      active_workers.erase(Thread::self());
     assert(count == 1);
 
     GASNetCondVar my_cv(lock);
@@ -762,7 +773,10 @@ namespace Realm {
 #endif
 
     // take ourselves off the active list (FOREVER...)
-    size_t count = active_workers.erase(me);
+#ifndef NDEBUG
+    size_t count =
+#endif
+      active_workers.erase(me);
     assert(count == 1);
 
     // also off the all workers list
@@ -989,7 +1003,10 @@ namespace Realm {
     //size_t count = active_workers.erase(Thread::self());
     //assert(count == 1);
 
-    size_t count = all_workers.erase(Thread::self());
+#ifndef NDEBUG
+    size_t count =
+#endif
+      all_workers.erase(Thread::self());
     assert(count == 1);
 
     // whoever we switch to should delete us

--- a/runtime/realm/threads.cc
+++ b/runtime/realm/threads.cc
@@ -825,7 +825,10 @@ namespace Realm {
       ThreadLocal::current_host_thread = ThreadLocal::current_thread;
       ThreadLocal::current_thread = switch_to;
 
-      int ret = swapcontext(&host_ctx, &switch_to->ctx);
+#ifndef NDEBUG
+      int ret =
+#endif
+	swapcontext(&host_ctx, &switch_to->ctx);
 
       // if we return with a value of 0, that means we were (eventually) given control
       //  back, as we hoped
@@ -848,7 +851,10 @@ namespace Realm {
 	ThreadLocal::current_thread = switch_to;
 
 	// a switch between two user contexts - nice and simple
-	int ret = swapcontext(&switch_from->ctx, &switch_to->ctx);
+#ifndef NDEBUG
+	int ret =
+#endif
+	  swapcontext(&switch_from->ctx, &switch_to->ctx);
 	assert(ret == 0);
 
 	assert(switch_from->running == false);
@@ -860,7 +866,10 @@ namespace Realm {
 	ThreadLocal::current_thread = ThreadLocal::current_host_thread;
 	ThreadLocal::current_host_thread = 0;
 
-	int ret = swapcontext(&switch_from->ctx, ThreadLocal::host_context);
+#ifndef NDEBUG
+	int ret =
+#endif
+	  swapcontext(&switch_from->ctx, ThreadLocal::host_context);
 	assert(ret == 0);
 
 	// if we get control back

--- a/runtime/shared_lowlevel.cc
+++ b/runtime/shared_lowlevel.cc
@@ -4030,8 +4030,11 @@ namespace LegionRuntime {
     {
       assert(fill_size == fill_value_size);
       size_t field_start = 0, field_size = 0, within_field = 0;
-      size_t bytes = find_field(get_field_sizes(), fill_offset, fill_size,
-                                field_start, field_size, within_field);
+#ifndef NDEBUG
+      size_t bytes =
+#endif
+	find_field(get_field_sizes(), fill_offset, fill_size,
+		   field_start, field_size, within_field);
       assert(bytes == fill_size);
       if (domain.get_dim() == 0) {
         if (linearization.get_dim() == 1) {
@@ -5203,8 +5206,11 @@ namespace LegionRuntime {
         RegionInstanceImpl *inst = rt->get_instance_impl(it->inst);
         // Find the field data for this field
         size_t field_start = 0, field_size = 0, within_field = 0;
-        size_t bytes = find_field(inst->get_field_sizes(), it->field_offset,
-                                  it->field_size, field_start, field_size, within_field);
+#ifndef NDEBUG
+        size_t bytes =
+#endif
+	  find_field(inst->get_field_sizes(), it->field_offset,
+		     it->field_size, field_start, field_size, within_field);
         // Should have at least enough bytes to read
         assert(bytes >= it->field_size);
         // Now iterate over all the points in the element space 
@@ -5314,8 +5320,11 @@ namespace LegionRuntime {
         RegionInstanceImpl *inst = rt->get_instance_impl(it->inst);
         // Find the field data for this field
         size_t field_start = 0, field_size = 0, within_field = 0;
-        size_t bytes = find_field(inst->get_field_sizes(), it->field_offset,
-                                  it->field_size, field_start, field_size, within_field);
+#ifndef NDEBUG
+        size_t bytes =
+#endif
+	  find_field(inst->get_field_sizes(), it->field_offset,
+		     it->field_size, field_start, field_size, within_field);
         // Should have at least enough bytes to read
         assert(bytes >= it->field_size);
         IndexSpaceImpl *source = rt->get_metadata_impl(it->index_space);
@@ -5371,8 +5380,11 @@ namespace LegionRuntime {
         RegionInstanceImpl *inst = rt->get_instance_impl(it->inst);
         // Find the field data for this field
         size_t field_start = 0, field_size = 0, within_field = 0;
-        size_t bytes = find_field(inst->get_field_sizes(), it->field_offset,
-                                  it->field_size, field_start, field_size, within_field);
+#ifndef NDEBUG
+        size_t bytes =
+#endif
+	  find_field(inst->get_field_sizes(), it->field_offset,
+		     it->field_size, field_start, field_size, within_field);
         // Should have at least enough bytes to read
         assert(bytes >= it->field_size);
         IndexSpaceImpl *source = rt->get_metadata_impl(it->index_space);
@@ -5596,7 +5608,7 @@ namespace LegionRuntime {
 	      size_t offset = i->offset;
 	      size_t size = i->size;
 	      while(size > 0) {
-		size_t field_start, field_size, within_field;
+		size_t field_start = 0, field_size = 0, within_field = 0;
 		size_t bytes = find_field(inst->get_field_sizes(), offset, size,
 					  field_start, field_size, within_field);
 		// printf("RD(%d,%d,%d)(%zd,%zd,%zd,%zd,%zd)(%p,%p)\n",
@@ -5621,7 +5633,7 @@ namespace LegionRuntime {
 	      size_t offset = i->offset;
 	      size_t size = i->size;
 	      while(size > 0) {
-		size_t field_start, field_size, within_field;
+		size_t field_start = 0, field_size = 0, within_field = 0;
 		size_t bytes = find_field(inst->get_field_sizes(), offset, size,
 					  field_start, field_size, within_field);
 		// printf("WR(%d,%d,%d)(%zd,%zd,%zd,%zd,%zd)(%p,%p)\n",


### PR DESCRIPTION
Modifications to avoid unused variable warnings when compiling with -DNDEBUG (assertions disabled).

There are still some warnings about missing return values in functions that just have the content "assert(0);", so still can't compile with the default -Werr.

Not sure if the intrusiveness of this change is worthwhile, but if you want the changes here they are.  I won't be heartbroken if the pull request is rejected.

Also contains some variable initializations where the compiler was warning about possibly uninitialized variables.