### PR TITLE
Added missing sys/types.h header to fix compile error on OSX

### DIFF
--- a/runtime/activemsg.h
+++ b/runtime/activemsg.h
@@ -24,6 +24,8 @@
 #include <stdlib.h>
 #include <vector>
 
+#include <sys/types.h>
+
     enum ActiveMessageIDs {
       FIRST_AVAILABLE = 140,
       NODE_ANNOUNCE_MSGID,


### PR DESCRIPTION
Added types.h to fix error

```shell
activemsg.h:843:9 error: 'off_t' has not been declared
```