### PR TITLE
cmake: use $MPI_INCLUDE as hint for gasnet

### DIFF
--- a/cmake/FindGASNet.cmake
+++ b/cmake/FindGASNet.cmake
@@ -185,6 +185,8 @@ if(NOT GASNet_FOUND AND NOT TARGET GASNet::GASNet)
   mark_as_advanced(GASNet_ROOT_DIR)
   if(GASNet_ROOT_DIR)
     set(_GASNet_FIND_INCLUDE_OPTS PATHS ${GASNet_ROOT_DIR}/include NO_DEFAULT_PATH)
+  else
+    set(_GASNet_FIND_INCLUDE_OPTS HINTS ENV MPI_INCLUDE)
   endif()
   find_path(GASNet_INCLUDE_DIR gasnet.h ${_GASNet_FIND_INCLUDE_OPTS})
 


### PR DESCRIPTION
Using $MPI_INCLUDE as a hint will help cmake to find mpi-enabled version of gasnet in Fedora.

/cc: @tuxfan 