### PR TITLE
Configfile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,17 @@ if(Legion_USE_HWLOC)
 endif()
 
 #------------------------------------------------------------------------------#
+# LuaJIT configuration
+#------------------------------------------------------------------------------#
+option(Legion_USE_LuaJIT "Use LuaJIT for config file" OFF)
+if(Legion_USE_LuaJIT)
+  find_package(LuaJIT REQUIRED)
+  install(FILES ${Legion_SOURCE_DIR}/cmake/FindLuaJIT.cmake
+    DESTINATION lib/cmake/Legion
+  )
+endif()
+
+#------------------------------------------------------------------------------#
 # GASNet configuration
 #------------------------------------------------------------------------------#
 option(Legion_USE_GASNet "Enable the distributed GASNet backend" OFF)

--- a/cmake/FindLuaJIT.cmake
+++ b/cmake/FindLuaJIT.cmake
@@ -1,0 +1,70 @@
+#------------------------------------------------------------------------------#
+# Copyright 2016 Kitware, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#------------------------------------------------------------------------------#
+
+find_path(LUA_INCLUDE_DIR luajit.h
+  HINTS
+    ENV LUAJIT
+  PATH_SUFFIXES include/luajit-2.0 include
+  PATHS
+  ~/Library/Frameworks
+  /Library/Frameworks
+  /sw # Fink
+  /opt/local # DarwinPorts
+  /opt/csw # Blastwave
+  /opt
+)
+
+find_library(LUA_LIBRARY
+  NAMES luajit-5.1
+  HINTS
+    ENV LUAJIT
+  PATH_SUFFIXES lib
+  PATHS
+  ~/Library/Frameworks
+  /Library/Frameworks
+  /sw
+  /opt/local
+  /opt/csw
+  /opt
+)
+
+if(LUA_LIBRARY)
+  # include the math library for Unix
+  if(UNIX AND NOT APPLE)
+    find_library(LUA_MATH_LIBRARY m)
+    set( LUA_LIBRARIES "${LUA_LIBRARY};${LUA_MATH_LIBRARY}" CACHE STRING "Lua Libraries")
+  # For Windows and Mac, don't need to explicitly include the math library
+  else()
+    set( LUA_LIBRARIES "${LUA_LIBRARY}" CACHE STRING "Lua Libraries")
+  endif()
+endif()
+
+if(LUA_INCLUDE_DIR AND EXISTS "${LUA_INCLUDE_DIR}/luajit.h")
+  file(STRINGS "${LUA_INCLUDE_DIR}/luajit.h" luajit_version_str REGEX "^#define[ \t]+LUAJIT_VERSION[ \t]+\"LuaJIT .+\"")
+
+  string(REGEX REPLACE "^#define[ \t]+LUAJIT_VERSION[ \t]+\"LuaJIT ([^\"]+)\".*" "\\1" LUAJIT_VERSION_STRING "${luajit_version_str}")
+  unset(luajit_version_str)
+endif()
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set LUA_FOUND to TRUE if
+# all listed variables are TRUE
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LuaJIT
+                                  REQUIRED_VARS LUA_LIBRARIES LUA_INCLUDE_DIR
+                                  VERSION_VAR LUAJIT_VERSION_STRING)
+
+mark_as_advanced(LUA_INCLUDE_DIR LUA_LIBRARIES LUA_LIBRARY LUA_MATH_LIBRARY)
+

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -76,6 +76,9 @@ else()
   if(Legion_USE_GASNet)
     list(APPEND LOW_RUNTIME_SRC activemsg.h activemsg.cc)
   endif()
+  if(Legion_USE_LuaJIT)
+    list(APPEND LOW_RUNTIME_SRC realm/options.h realm/options.cc)
+  endif()
 endif()
 list(APPEND LOW_RUNTIME_SRC
   accessor.h
@@ -160,6 +163,12 @@ if(Legion_USE_CUDA)
   target_compile_definitions(LowLevelRuntime PUBLIC USE_CUDA)
   target_include_directories(LowLevelRuntime PRIVATE ${CUDA_INCLUDE_DIRS})
   target_link_libraries(LowLevelRuntime PRIVATE ${CUDA_CUDA_LIBRARY})
+endif()
+
+if(Legion_USE_LuaJIT)
+  target_compile_definitions(LowLevelRuntime PUBLIC REALM_USE_LUAJIT)
+  target_include_directories(LowLevelRuntime PRIVATE ${LUA_INCLUDE_DIR})
+  target_link_libraries(LowLevelRuntime PRIVATE ${LUA_LIBRARIES})
 endif()
 
 if(Legion_USE_SHARED_LOWLEVEL)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -257,6 +257,10 @@ target_include_directories(HighLevelRuntime
   PRIVATE legion realm mappers
 )
 
+if(Legion_USE_LuaJIT)
+  target_include_directories(HighLevelRuntime PRIVATE ${LUA_INCLUDE_DIR})
+endif()
+
 install(TARGETS HighLevelRuntime EXPORT LegionTargets
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/runtime/mappers/default_mapper.cc
+++ b/runtime/mappers/default_mapper.cc
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+#include "realm/options.h"
 #include "legion.h"
 #include "default_mapper.h"
 
@@ -75,27 +76,21 @@ namespace Legion {
       {
         int argc = HighLevelRuntime::get_input_args().argc;
         char **argv = HighLevelRuntime::get_input_args().argv;
-        // Parse the input arguments looking for ones for the default mapper
-        for (int i=1; i < argc; i++)
-        {
-#define INT_ARG(argname, varname) do {      \
-          if (!strcmp(argv[i], argname)) {  \
-            varname = atoi(argv[++i]);      \
-            continue;                       \
-          } } while(0);
-#define BOOL_ARG(argname, varname) do {       \
-          if (!strcmp(argv[i], argname)) {    \
-            varname = (atoi(argv[++i]) != 0); \
-            continue;                         \
-          } } while(0);
-          INT_ARG("-dm:thefts", max_steals_per_theft);
-          INT_ARG("-dm:count", max_steal_count);
-          BOOL_ARG("-dm:steal", stealing_enabled);
-          BOOL_ARG("-dm:bft", breadth_first_traversal);
-          INT_ARG("-dm:sched", max_schedule_count);
-#undef BOOL_ARG
-#undef INT_ARG
+        std::vector<std::string> cmdline;
+        if(argc > 1) {
+          cmdline.resize(argc - 1);
+          for(int i = 1; i < argc; i++)
+            cmdline[i - 1] = argv[i];
         }
+        Realm::OptionParser cp(cmdline);
+        // Parse the input arguments looking for ones for the default mapper
+        
+        cp.add_option_int("-dm:thefts", max_steals_per_theft);
+        cp.add_option_int("-dm:count", max_steal_count);
+        cp.add_option_bool("-dm:steal", stealing_enabled);
+        cp.add_option_bool("-dm:bft", breadth_first_traversal);
+        cp.add_option_int("-dm:sched", max_schedule_count);
+        cp.parse_command_line(cmdline);
       }
       if (stealing_enabled)
       {

--- a/runtime/mappers/shim_mapper.cc
+++ b/runtime/mappers/shim_mapper.cc
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+#include "realm/options.h"
 #include "legion.h"
 #include "shim_mapper.h"
 
@@ -415,31 +416,27 @@ namespace Legion {
         int argc = Runtime::get_input_args().argc;
         char **argv = Runtime::get_input_args().argv;
         unsigned num_profiling_samples = STATIC_NUM_PROFILE_SAMPLES;
-        // Parse the input arguments looking for ones for the shim mapper
-        for (int i=1; i < argc; i++)
-        {
-#define INT_ARG(argname, varname) do {      \
-          if (!strcmp(argv[i], argname)) {  \
-            varname = atoi(argv[++i]);      \
-            continue;                       \
-          } } while(0);
-#define BOOL_ARG(argname, varname) do {       \
-          if (!strcmp(argv[i], argname)) {    \
-            varname = (atoi(argv[++i]) != 0); \
-            continue;                         \
-          } } while(0);
-          INT_ARG("-dm:thefts", max_steals_per_theft);
-          INT_ARG("-dm:count", max_steal_count);
-          INT_ARG("-dm:split", splitting_factor);
-          BOOL_ARG("-dm:war", war_enabled);
-          BOOL_ARG("-dm:steal", stealing_enabled);
-          BOOL_ARG("-dm:bft", breadth_first_traversal);
-          INT_ARG("-dm:sched", max_schedule_count);
-          INT_ARG("-dm:prof",num_profiling_samples);
-          INT_ARG("-dm:fail",max_failed_mappings);
-#undef BOOL_ARG
-#undef INT_ARG
+
+        std::vector<std::string> cmdline;
+        if(argc > 1) {
+          cmdline.resize(argc - 1);
+          for(int i = 1; i < argc; i++)
+            cmdline[i - 1] = argv[i];
         }
+        Realm::OptionParser cp(cmdline);
+
+        // Parse the input arguments looking for ones for the shim mapper
+        cp.add_option_int("-dm:thefts", max_steals_per_theft);
+        cp.add_option_int("-dm:count", max_steal_count);
+        cp.add_option_int("-dm:split", splitting_factor);
+        cp.add_option_bool("-dm:war", war_enabled);
+        cp.add_option_bool("-dm:steal", stealing_enabled);
+        cp.add_option_bool("-dm:bft", breadth_first_traversal);
+        cp.add_option_int("-dm:sched", max_schedule_count);
+        cp.add_option_int("-dm:prof", num_profiling_samples);
+        cp.add_option_int("-dm:fail", max_failed_mappings);
+        cp.parse_command_line(cmdline);
+
         profiler.set_needed_profiling_samples(num_profiling_samples);
       }
     }

--- a/runtime/mappers/test_mapper.cc
+++ b/runtime/mappers/test_mapper.cc
@@ -13,6 +13,7 @@
  * limitations under the License.
  */
 
+#include "realm/options.h"
 #include "test_mapper.h"
 #include <sys/time.h>
 
@@ -50,17 +51,18 @@ namespace Legion {
       {
         int argc = HighLevelRuntime::get_input_args().argc;
         char **argv = HighLevelRuntime::get_input_args().argv;
-        // Parse the input arguments looking for ones for the default mapper
-        for (int i=1; i < argc; i++)
-        {
-#define INT_ARG(argname, varname) do {      \
-          if (!strcmp(argv[i], argname)) {  \
-            varname = atoi(argv[++i]);      \
-            continue;                       \
-          } } while(0);
-          INT_ARG("-tm:seed", seed);
-#undef INT_ARG
+
+        std::vector<std::string> cmdline;
+        if(argc > 1) {
+          cmdline.resize(argc - 1);
+          for(int i = 1; i < argc; i++)
+            cmdline[i - 1] = argv[i];
         }
+        Realm::OptionParser cp(cmdline);
+        // Parse the input arguments looking for ones for the default mapper
+        
+        cp.add_option_int("-tm:seed", seed);
+        cp.parse_command_line(cmdline);
       }
       if (seed == -1)
       {

--- a/runtime/realm/cmdline.cc
+++ b/runtime/realm/cmdline.cc
@@ -147,6 +147,18 @@ namespace Realm {
   }
 
   template <>
+  bool convert_integer_cmdline_argument<long long>(const std::string& s, long long& target)
+  {
+    errno = 0;  // no errors from before
+    char *pos;
+    target = strtoul(s.c_str(), &pos, 10);
+    if((errno == 0) && (*pos == 0)) {
+      return true;
+    } else 
+      return false;
+  }
+
+  template <>
   bool convert_integer_cmdline_argument<bool>(const std::string& s, bool& target)
   {
     errno = 0;  // no errors from before

--- a/runtime/realm/cmdline.inl
+++ b/runtime/realm/cmdline.inl
@@ -99,6 +99,9 @@ namespace Realm {
 
   template <>
   bool convert_integer_cmdline_argument<unsigned long>(const std::string& s, unsigned long& target);
+  
+  template <>
+  bool convert_integer_cmdline_argument<long long>(const std::string& s, long long& target);
 
   template <>
   bool convert_integer_cmdline_argument<bool>(const std::string& s, bool& target);

--- a/runtime/realm/cuda/cuda_module.cc
+++ b/runtime/realm/cuda/cuda_module.cc
@@ -17,7 +17,7 @@
 
 #include "realm/tasks.h"
 #include "realm/logging.h"
-#include "realm/cmdline.h"
+#include "realm/options.h"
 
 #include "lowlevel_dma.h"
 
@@ -2172,7 +2172,7 @@ namespace Realm {
 
       // first order of business - read command line parameters
       {
-	CommandLineParser cp;
+	OptionParser cp(cmdline);
 
 	cp.add_option_int("-ll:fsize", m->cfg_fb_mem_size_in_mb)
 	  .add_option_int("-ll:zsize", m->cfg_zc_mem_size_in_mb)

--- a/runtime/realm/hdf5/hdf5_module.cc
+++ b/runtime/realm/hdf5/hdf5_module.cc
@@ -18,7 +18,7 @@
 #include "hdf5_internal.h"
 
 #include "logging.h"
-#include "cmdline.h"
+#include "options.h"
 #include "threads.h"
 #include "runtime_impl.h"
 #include "utils.h"
@@ -60,7 +60,7 @@ namespace Realm {
 
       // first order of business - read command line parameters
       {
-	CommandLineParser cp;
+	OptionParser cp(cmdline);
 
 	cp.add_option_bool("-hdf5:showerrors", m->cfg_showerrors);
 	

--- a/runtime/realm/logging.cc
+++ b/runtime/realm/logging.cc
@@ -24,7 +24,7 @@
 #include "activemsg.h"
 #endif
 
-#include "cmdline.h"
+#include "options.h"
 
 #include <stdio.h>
 #include <string.h>
@@ -294,7 +294,7 @@ namespace Realm {
   {
     std::string logname;
 
-    bool ok = CommandLineParser()
+    bool ok = OptionParser(cmdline)
       .add_option_string("-cat", cats_enabled)
       .add_option_string("-logfile", logname)
       .add_option_method("-level", this, &LoggerConfig::parse_level_argument)

--- a/runtime/realm/numa/numa_module.cc
+++ b/runtime/realm/numa/numa_module.cc
@@ -17,7 +17,7 @@
 
 #include "numasysif.h"
 #include "logging.h"
-#include "cmdline.h"
+#include "options.h"
 #include "proc_impl.h"
 #include "threads.h"
 #include "runtime_impl.h"
@@ -105,8 +105,7 @@ namespace Realm {
 
       // first order of business - read command line parameters
       {
-	CommandLineParser cp;
-
+	OptionParser cp(cmdline);
 	cp.add_option_int("-ll:nsize", m->cfg_numa_mem_size_in_mb)
 	  .add_option_int("-ll:ncpu", m->cfg_num_numa_cpus)
 	  .add_option_bool("-numa:pin", m->cfg_pin_memory);

--- a/runtime/realm/options.cc
+++ b/runtime/realm/options.cc
@@ -1,0 +1,129 @@
+/* Copyright 2016 Stanford University, NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "options.h"
+#include "logging.h"
+
+namespace Realm {
+
+  Logger log_config("config");
+
+
+  // convert command line options to lua variable names
+  // -level -> opt_level
+  // -ll:cpu -> opt_ll_cpu
+  // etc
+  std::string luaName(const std::string& optname)
+  {
+    std::string name = optname;
+
+    // replace : w/ _
+    size_t cidx = name.find(":");
+    if (cidx != std::string::npos) {
+      name.replace(cidx, 1, "_");
+    }
+    return "opt_" + name.substr(1); // replace dash w/ opt_
+  }
+
+  OptionParser::OptionParser(std::vector<std::string>& cmdline)
+  {
+    std::string luaConfig; 
+    CommandLineParser cpf;
+    cpf.add_option_string("-ll:lua_config", luaConfig);
+    cpf.parse_command_line(cmdline);
+   
+    luaState = luaL_newstate();
+    if(!luaState) {
+      log_config.fatal("could not get lua state");
+    }
+ 
+    // Open standard libraries 
+    luaL_openlibs(luaState); 
+    // Load config file
+    if(!luaConfig.empty()) { 
+      if (luaL_loadfile(luaState, luaConfig.c_str()) == 0) {
+        int ret = lua_pcall(luaState, 0, 0, 0);
+        if (ret != 0) {
+          log_config.fatal(lua_tostring(luaState, -1));
+        }
+      } else {
+          log_config.fatal("invalid lua config file");
+      }
+    } else {
+      luaConfig = "config.lua";
+      log_config.info("using default config.lua");
+      if (luaL_loadfile(luaState, luaConfig.c_str()) == 0) {
+        int ret = lua_pcall(luaState, 0, 0, 0);
+        if (ret != 0) {
+          log_config.fatal(lua_tostring(luaState, -1));
+        }
+      } else {
+         log_config.info("invalid or missing config.lua");
+         luaState = NULL;
+      }
+    }
+  }
+
+  OptionParser::~OptionParser(void) 
+  {
+     if (luaState) lua_close(luaState); 
+  }
+
+  void OptionParser::parse_configfile_option(const std::string& optname, int& target) 
+  {
+    if (luaState) {
+      std::string name = luaName(optname);
+      lua_getglobal(luaState, name.c_str());
+      if (lua_isnumber(luaState, -1 )) {
+        target = lua_tointeger(luaState, -1 );
+      }
+      lua_settop(luaState, 0);
+    }
+  }
+
+  void OptionParser::parse_configfile_option(const std::string& optname, bool& target)
+  {
+    if (luaState) {
+      std::string name = luaName(optname);
+      lua_getglobal(luaState, name.c_str());
+      // accept 0/1 or true/false
+      if (lua_isnumber(luaState, -1 )) {
+        if (lua_tointeger(luaState, -1 ) == 1) {
+          target = true;
+        }
+      } else if (lua_isboolean(luaState, -1 )) {
+        if (lua_toboolean(luaState, -1 ) == 1) {
+          target = true;
+        }
+      }
+      lua_settop(luaState, 0);
+    }
+  }
+
+  void OptionParser::parse_configfile_option(const std::string& optname, std::string& target)
+  {
+    if (luaState) {
+      std::string name = luaName(optname);
+      lua_getglobal(luaState, name.c_str());
+      const char *str = lua_tostring(luaState, -1);
+      if (str != NULL) {
+        target = std::string(str);
+      }
+      lua_settop(luaState, 0);
+    }
+  } 
+
+}; // namespace Realm

--- a/runtime/realm/options.h
+++ b/runtime/realm/options.h
@@ -1,0 +1,78 @@
+/* Copyright 2016 Stanford University, NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef REALM_CONFIGFILE_H
+#define REALM_CONFIGFILE_H
+
+#include "cmdline.h"
+
+#ifdef REALM_USE_LUAJIT
+
+#include <string>
+#include <vector>
+
+extern "C" {
+#include <lua.h>
+#include <lualib.h>
+#include <lauxlib.h>
+
+}
+
+namespace Realm {
+
+  class OptionParser : public CommandLineParser {
+  public:
+     OptionParser(std::vector<std::string>& cmdline);
+    ~OptionParser(void);
+
+    template <typename T>
+    OptionParser& add_option_int(const std::string& optname, T& target, bool keep = false);
+
+    template <typename T>
+    OptionParser& add_option_string(const std::string& optname, T& target, bool keep = false);
+
+    OptionParser& add_option_bool(const std::string& optname, bool& target, bool keep = false);
+
+    template <typename T>
+    OptionParser& add_option_method(const std::string& optname, T *target,
+                     bool (T::*method)(const std::string&), bool keep = false);
+
+    void parse_configfile_option(const std::string& optname, bool& target);
+    void parse_configfile_option(const std::string& optname, int& target);
+    void parse_configfile_option(const std::string& optname, std::string& target);
+
+  protected:
+    lua_State *luaState;
+  };
+
+
+}; // namespace Realm
+
+#include "options.inl"
+
+#else
+
+// no luajit just use CommandLineParser
+namespace Realm {
+  class OptionParser : public CommandLineParser {
+  public: 
+     OptionParser(std::vector<std::string>& cmdline) {} 
+  };
+}; 
+
+#endif
+
+#endif
+

--- a/runtime/realm/options.inl
+++ b/runtime/realm/options.inl
@@ -1,0 +1,69 @@
+/* Copyright 2016 Stanford University, NVIDIA Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+namespace Realm {
+
+  // command line options will override those in config file as
+  // config file parsing is done in the parse_configfile_option functions
+  // and command line is done in parse_command_line
+
+  template <typename T>
+  OptionParser& OptionParser::add_option_int(const std::string& optname,
+                               T& target,
+                               bool keep /*= false*/)
+  {
+    CommandLineParser::add_option_int(optname, target, keep);
+    int x = static_cast<int>(target); 
+    parse_configfile_option(optname, x);
+    target = static_cast<T>(x);
+    return *this;
+  }
+
+
+  template <typename T>
+  OptionParser& OptionParser::add_option_string(const std::string& optname,
+                              T& target,
+                              bool keep /*= false*/)
+  {
+    CommandLineParser::add_option_string(optname, target, keep);
+    parse_configfile_option(optname, target);
+    return *this;
+  }
+
+  inline OptionParser& OptionParser::add_option_bool(const std::string& optname,
+                                   bool& target,
+                                   bool keep /*= false*/)
+  {
+    CommandLineParser::add_option_bool(optname, target, keep);
+    parse_configfile_option(optname, target);
+    return *this;
+  }
+
+  template <typename T>
+  OptionParser& OptionParser::add_option_method(const std::string& optname,
+                              T *target,
+                              bool (T::*method)(const std::string&),
+                              bool keep /*= false*/)
+  {
+    CommandLineParser::add_option_method(optname, target, method, keep);
+    std::string str;
+    parse_configfile_option(optname, str);
+    (target->*method)(str);
+
+    return *this;
+  }
+
+}; // namespace Realm

--- a/runtime/realm/procset/procset_module.cc
+++ b/runtime/realm/procset/procset_module.cc
@@ -16,7 +16,7 @@
 #include "procset_module.h"
 
 #include "logging.h"
-#include "cmdline.h"
+#include "options.h"
 #include "proc_impl.h"
 #include "threads.h"
 #include "runtime_impl.h"
@@ -97,7 +97,7 @@ namespace Realm {
       ProcSetModule *m = new ProcSetModule;
 
       // read command line parameters
-	  CommandLineParser cp;
+      OptionParser cp(cmdline);
 
       cp.add_option_int("-ll:mp_threads", m->cfg_num_mp_threads)
         .add_option_int("-ll:mp_nodes", m->cfg_num_mp_procs)
@@ -108,6 +108,7 @@ namespace Realm {
 	    log_procset.fatal() << "error reading ProcSet command line parameters";
 	    assert(false);
 	  }
+
       return m;
     }
 

--- a/runtime/realm/runtime_impl.cc
+++ b/runtime/realm/runtime_impl.cc
@@ -23,7 +23,7 @@
 
 #include "activemsg.h"
 
-#include "cmdline.h"
+#include "options.h"
 
 #include "codedesc.h"
 
@@ -289,7 +289,7 @@ namespace Realm {
     CoreModule *m = new CoreModule;
 
     // parse command line arguments
-    CommandLineParser cp;
+    OptionParser cp(cmdline);
     cp.add_option_int("-ll:cpu", m->num_cpu_procs)
       .add_option_int("-ll:util", m->num_util_procs)
       .add_option_int("-ll:io", m->num_io_procs)
@@ -657,7 +657,7 @@ namespace Realm {
       // are hyperthreads considered to share a physical core
       bool hyperthread_sharing = true;
 
-      CommandLineParser cp;
+      OptionParser cp(cmdline);
       cp.add_option_int("-ll:gsize", gasnet_mem_size_in_mb)
 	.add_option_int("-ll:rsize", reg_mem_size_in_mb)
 	.add_option_int("-ll:dsize", disk_mem_size_in_mb)

--- a/runtime/realm/sampling_impl.cc
+++ b/runtime/realm/sampling_impl.cc
@@ -16,7 +16,7 @@
 // sampling profiler implementation for Realm
 
 #include "sampling_impl.h"
-#include "cmdline.h"
+#include "options.h"
 #include "timers.h"
 
 #include <unistd.h>
@@ -471,7 +471,7 @@ namespace Realm {
 #ifndef NDEBUG
     bool ok =
 #endif
-              CommandLineParser()
+              OptionParser(cmdline)
       .add_option_int("-realm:prof", nodes_profiled)
       .add_option_string("-realm:prof_file", logfile)
       .add_option_int("-realm:prof_buffer_size", cfg_buffer_size)

--- a/runtime/runtime.mk
+++ b/runtime/runtime.mk
@@ -125,6 +125,15 @@ ifeq ($(strip $(USE_HWLOC)),1)
   LEGION_LD_FLAGS += -L$(HWLOC)/lib -lhwloc
 endif
 
+ifeq ($(strip $(USE_LUAJIT)),1)
+  ifndef LUAJIT 
+    $(error LUAJIT variable is not defined, aborting build)
+  endif
+  CC_FLAGS        += -DREALM_USE_LUAJIT
+  INC_FLAGS   += -I$(LUAJIT)/include/luajit-2.0
+  LEGION_LD_FLAGS += -L$(LUAJIT)/lib -lluajit-5.1
+endif
+
 ifeq ($(strip $(USE_PAPI)),1)
   ifndef PAPI_ROOT
     ifdef PAPI
@@ -358,6 +367,9 @@ endif
 ifeq ($(strip $(USE_GASNET)),1)
 LOW_RUNTIME_SRC += $(LG_RT_DIR)/activemsg.cc
 endif
+ifeq ($(strip $(USE_LUAJIT)),1)
+LOW_RUNTIME_SRC += $(LG_RT_DIR)/realm/options.cc
+endif
 GPU_RUNTIME_SRC +=
 else
 CC_FLAGS	+= -DSHARED_LOWLEVEL
@@ -367,7 +379,7 @@ LOW_RUNTIME_SRC += $(LG_RT_DIR)/realm/logging.cc \
 	           $(LG_RT_DIR)/realm/cmdline.cc \
 		   $(LG_RT_DIR)/realm/profiling.cc \
 	           $(LG_RT_DIR)/realm/codedesc.cc \
-		   $(LG_RT_DIR)/realm/timers.cc
+		   $(LG_RT_DIR)/realm/timers.cc 
 
 MAPPER_SRC	+= $(LG_RT_DIR)/mappers/default_mapper.cc \
 		   $(LG_RT_DIR)/mappers/mapping_utilities.cc \


### PR DESCRIPTION
Add support for a Lua based configuration file for setting runtime options rather than specifying them on the command line.

Default config file is "config.lua" or it can be specified with -ll:lua_config

Lua variables corresponding to runtime variables start with the prefix “opt_” so –level becomes opt_level. “:” is replaced by “_” so “–ll:cpu” becomes opt_ll_cpu etc.

This allows for example to only specify an option on a given node e.g.

if hostname() == "foo" then
  opt_level = "realm=0"
end
