### PR TITLE
cmake: syntax error

### DIFF
--- a/cmake/FindGASNet.cmake
+++ b/cmake/FindGASNet.cmake
@@ -185,7 +185,7 @@ if(NOT GASNet_FOUND AND NOT TARGET GASNet::GASNet)
   mark_as_advanced(GASNet_ROOT_DIR)
   if(GASNet_ROOT_DIR)
     set(_GASNet_FIND_INCLUDE_OPTS PATHS ${GASNet_ROOT_DIR}/include NO_DEFAULT_PATH)
-  else
+  else()
     set(_GASNet_FIND_INCLUDE_OPTS HINTS ENV MPI_INCLUDE)
   endif()
   find_path(GASNet_INCLUDE_DIR gasnet.h ${_GASNet_FIND_INCLUDE_OPTS})


### PR DESCRIPTION
introduced in a76904852c60b5b2d80508e32cd69694c2aff1fc, #196
