### PR TITLE
cmake: bump min. version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 #------------------------------------------------------------------------------#
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.6)
 project(Legion)
 
 #------------------------------------------------------------------------------#


### PR DESCRIPTION
need for cmake-3.6 got introduced in #188, 3b10b9d2d48de10cf26c05a248a9747e2a01fd95
