### PR TITLE
Make git submodule relative

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "language/src/rdir"]
 	path = language/src/rdir
-	url = https://github.com/StanfordLegion/rdir.git
+	url = ../rdir.git


### PR DESCRIPTION
This help to inherit the same transport protocol as used for the
main repo. e.g. if https is not available (see losalamos/flecsi-third-party#11)