### PR TITLE
Cmake from lanl2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ set(SOVERSION 1)
 set(CMAKE_BUILD_TYPE  Debug CACHE STRING "Choose the type of build" FORCE)
 set(BUILD_SHARED_LIBS OFF   CACHE BOOL   "Whether or not to build shared libraries instead of static")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DLEGION_CMAKE")
+add_definitions(-DLEGION_CMAKE)
 
 #https://github.com/StanfordLegion/legion/issues/168#issuecomment-244582958
 include(CheckCXXCompilerFlag)
@@ -54,7 +54,7 @@ if(COMPILER_SUPPORTS_NO_STRICT_ALIASING)
 endif()
 
 if (${CMAKE_BUILD_TYPE} EQUAL "Debug")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDEBUG_REALM -DDEBUG_LEGION")
+  add_definitions(-DDEBUG_REALM -DDEBUG_LEGION)
   set(DEBUG_REALM ON)
   set(DEBUG_LEGION ON)
 endif()
@@ -126,8 +126,8 @@ if(Legion_USE_CUDA)
   install(FILES ${Legion_SOURCE_DIR}/cmake/newcmake/FindCUDA.cmake
     DESTINATION ${CMAKE_INSTALL_DATADIR}/Legion/cmake/newcmake
   )
- 
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_CUDA")
+
+  add_definitions(-DUSE_CUDA) 
 
 endif()
 
@@ -238,11 +238,10 @@ endif()
 # configure header
 #------------------------------------------------------------------------------#
 
-configure_file(${PROJECT_SOURCE_DIR}/cmake/legion_defines.h.in ${PROJECT_SOURCE_DIR}/legion_defines.h @ONLY)
+configure_file(${PROJECT_SOURCE_DIR}/cmake/legion_defines.h.in ${PROJECT_SOURCE_DIR}/runtime/legion_defines.h @ONLY)
+include_directories(${PROJECT_SOURCE_DIR}/runtime)
+install(FILES ${PROJECT_SOURCE_DIR}/runtime/legion_defines.h DESTINATION include)
 
-install(FILES ${PROJECT_SOURCE_DIR}/legion_defines.h DESTINATION include)
-#include_directories(${CMAKE_BINARY_DIR})
-#install(FILES ${CMAKE_BINARY_DIR}/legion_defines.h DESTINATION include)
 
 #------------------------------------------------------------------------------#
 # vim: set tabstop=2 shiftwidth=2 expandtab :

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,6 @@ if(COMPILER_SUPPORTS_NO_STRICT_ALIASING)
 endif()
 
 if (${CMAKE_BUILD_TYPE} EQUAL "Debug")
-  add_definitions(-DDEBUG_REALM -DDEBUG_LEGION)
   set(DEBUG_REALM ON)
   set(DEBUG_LEGION ON)
 endif()
@@ -127,7 +126,7 @@ if(Legion_USE_CUDA)
     DESTINATION ${CMAKE_INSTALL_DATADIR}/Legion/cmake/newcmake
   )
 
-  add_definitions(-DUSE_CUDA) 
+  set (USE_CUDA ON)
 
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,12 @@ if(COMPILER_SUPPORTS_NO_STRICT_ALIASING)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-strict-aliasing")
 endif()
 
+if (${CMAKE_BUILD_TYPE} EQUAL "Debug")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DDEBUG_REALM -DDEBUG_LEGION")
+  set(DEBUG_REALM ON)
+  set(DEBUG_LEGION ON)
+endif()
+
 #------------------------------------------------------------------------------#
 # Minimum log level
 #------------------------------------------------------------------------------#
@@ -82,6 +88,11 @@ if(Legion_USE_GASNet)
   install(FILES ${Legion_SOURCE_DIR}/cmake/FindGASNet.cmake
     DESTINATION ${CMAKE_INSTALL_DATADIR}/Legion/cmake
   )
+
+  set (GASNETI_BUG1389_WORKAROUND "1")
+  string(TOUPPER ${GASNet_CONDUIT} CONDUIT)
+  set (GASNET_CONDUIT_${CONDUIT} ON)
+
 endif()
 
 #------------------------------------------------------------------------------#
@@ -113,6 +124,9 @@ if(Legion_USE_CUDA)
   install(FILES ${Legion_SOURCE_DIR}/cmake/newcmake/FindCUDA.cmake
     DESTINATION ${CMAKE_INSTALL_DATADIR}/Legion/cmake/newcmake
   )
+ 
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_CUDA")
+
 endif()
 
 #------------------------------------------------------------------------------#
@@ -128,6 +142,20 @@ mark_as_advanced(Legion_MAX_FIELDS)
 # Runtime library targets
 #------------------------------------------------------------------------------#
 add_subdirectory(runtime)
+
+#------------------------------------------------------------------------------#
+# configure header
+#------------------------------------------------------------------------------#
+# Checking for all defines in the CXX Flags
+string(REPLACE " " ";" FLAGS_LIST ${CMAKE_CXX_FLAGS})
+FOREACH(FLAG ${FLAGS_LIST})
+  string (FIND ${FLAG} "-D" START_STR)
+  if (${START_STR} EQUAL "0")
+  string(REPLACE "-D" "" NEW_DEFINE ${FLAG})
+  set (NEW_DEFINE ON)
+  endif()
+endforeach()
+
 
 #------------------------------------------------------------------------------#
 # Build-tree package generation
@@ -203,6 +231,14 @@ if(Legion_BUILD_EXAMPLES OR Legion_BUILD_EXAMPLE_APPS)
     add_subdirectory(apps)
   endif()
 endif()
+
+#------------------------------------------------------------------------------#
+# configure header
+#------------------------------------------------------------------------------#
+
+configure_file(${PROJECT_SOURCE_DIR}/cmake/legion_defines.h.in ${CMAKE_BINARY_DIR}/legion_defines.h @ONLY)
+include_directories(${CMAKE_BINARY_DIR})
+install(FILES ${CMAKE_BINARY_DIR}/legion_defines.h DESTINATION include)
 
 #------------------------------------------------------------------------------#
 # vim: set tabstop=2 shiftwidth=2 expandtab :

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ set(SOVERSION 1)
 set(CMAKE_BUILD_TYPE  Debug CACHE STRING "Choose the type of build" FORCE)
 set(BUILD_SHARED_LIBS OFF   CACHE BOOL   "Whether or not to build shared libraries instead of static")
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DLEGION_CMAKE")
+
 #https://github.com/StanfordLegion/legion/issues/168#issuecomment-244582958
 include(CheckCXXCompilerFlag)
 check_cxx_compiler_flag("-fno-strict-aliasing" COMPILER_SUPPORTS_NO_STRICT_ALIASING)
@@ -152,7 +154,7 @@ FOREACH(FLAG ${FLAGS_LIST})
   string (FIND ${FLAG} "-D" START_STR)
   if (${START_STR} EQUAL "0")
   string(REPLACE "-D" "" NEW_DEFINE ${FLAG})
-  set (NEW_DEFINE ON)
+  set (${NEW_DEFINE} ON)
   endif()
 endforeach()
 
@@ -236,9 +238,11 @@ endif()
 # configure header
 #------------------------------------------------------------------------------#
 
-configure_file(${PROJECT_SOURCE_DIR}/cmake/legion_defines.h.in ${CMAKE_BINARY_DIR}/legion_defines.h @ONLY)
-include_directories(${CMAKE_BINARY_DIR})
-install(FILES ${CMAKE_BINARY_DIR}/legion_defines.h DESTINATION include)
+configure_file(${PROJECT_SOURCE_DIR}/cmake/legion_defines.h.in ${PROJECT_SOURCE_DIR}/legion_defines.h @ONLY)
+
+install(FILES ${PROJECT_SOURCE_DIR}/legion_defines.h DESTINATION include)
+#include_directories(${CMAKE_BINARY_DIR})
+#install(FILES ${CMAKE_BINARY_DIR}/legion_defines.h DESTINATION include)
 
 #------------------------------------------------------------------------------#
 # vim: set tabstop=2 shiftwidth=2 expandtab :

--- a/cmake/legion_defines.h.in
+++ b/cmake/legion_defines.h.in
@@ -1,0 +1,16 @@
+// -----------------------------------------------------------------------//
+// save all Legion defines in the legion_defines.h file
+// -----------------------------------------------------------------------//
+
+#cmakedefine DEBUG_REALM 
+#cmakedefine DEBUG_LEGION
+#cmakedefine PRIVILEGE_CHECKS
+#cmakedefine BOUNDS_CHECKS
+#cmakedefine GASNET_CONDUIT_MPI
+#cmakedefine GASNET_CONDUIT_IBV
+#cmakedefine GASNET_CONDUIT_UDP
+#cmakedefine GASNET_CONDUIT_ARIES
+#cmakedefine GASNET_CONDUIT_GEMINI
+#cmakedefine USE_CUDA
+#cmakedefine GASNETI_BUG1389_WORKAROUND @GASNETI_BUG1389_WORKAROUND@
+

--- a/cmake/legion_defines.h.in
+++ b/cmake/legion_defines.h.in
@@ -14,3 +14,5 @@
 #cmakedefine USE_CUDA
 #cmakedefine GASNETI_BUG1389_WORKAROUND @GASNETI_BUG1389_WORKAROUND@
 
+#include "legion.h"
+

--- a/runtime/legion/legion.h
+++ b/runtime/legion/legion.h
@@ -29,6 +29,9 @@
  * \file legion.h
  * Legion C++ API
  */
+#ifdef LEGION_CMAKE
+#include "legion_defines.h"
+#endif
 
 #include "legion_types.h"
 #include "legion_constraint.h"

--- a/runtime/legion/legion_tasks.cc
+++ b/runtime/legion/legion_tasks.cc
@@ -4110,7 +4110,7 @@ namespace Legion {
                                                          output.slices.size());
         slices.push_back(new_slice);
       }
-#if DEBUG_LEGION
+#ifdef DEBUG_LEGION
       // If the volumes don't match, then something bad happend in the mapper
       if (total_points != internal_domain.get_volume())
       {


### PR DESCRIPTION
A fix for the CMake build issue with propagation compile-time definitions to other projects, that are built on top of the Legion:
1)  CMAKE generates legion_defines.h file where it stores all definitions
2) In case Legion is built with CMake, legion_defines.h file gets included into legion.h

@chuckatkins, @streichler : please review