### PR TITLE
Realm::get_bd_sibling_id: fix return for single thread

### DIFF
--- a/runtime/realm/threads.cc
+++ b/runtime/realm/threads.cc
@@ -1343,6 +1343,7 @@ namespace Realm {
     f = fopen(str, "r");
     if(!f) {
       std::cout << "can't read '" << str << "' - skipping";
+      return -1;
     }
     int sib_core_id;
     int count = fscanf(f, "%d", &sib_core_id);


### PR DESCRIPTION
Fixes #230