### PR TITLE
Updated FindGASNET function to add MPI include path

### DIFF
--- a/cmake/FindGASNet.cmake
+++ b/cmake/FindGASNet.cmake
@@ -158,6 +158,7 @@ function(_GASNet_create_component_target _GASNet_MAKEFILE COMPONENT_NAME
     set(MPI_C_COMPILER ${_GASNet_LD})
     find_package(MPI REQUIRED COMPONENTS C)
     list(APPEND COMPONENT_DEPS ${MPI_C_LIBRARIES})
+    list(APPEND IDIRS ${MPI_C_INCLUDE_PATH})
   endif()
   add_library(GASNet::${COMPONENT_NAME} UNKNOWN IMPORTED)
   set_target_properties(GASNet::${COMPONENT_NAME} PROPERTIES


### PR DESCRIPTION
The mpi_interop example includes mpi.h and needs the MPI include path found in FindGASNet. @junghans 