### PR TITLE
cmake: link mpi_interop against mpi

### DIFF
--- a/examples/mpi_interop/CMakeLists.txt
+++ b/examples/mpi_interop/CMakeLists.txt
@@ -22,8 +22,11 @@ if(NOT Legion_SOURCE_DIR)
   find_package(Legion REQUIRED)
 endif()
 
+find_package(MPI REQUIRED)
+
 add_executable(mpi_interop mpi_interop.cc)
-target_link_libraries(mpi_interop Legion::Legion)
+target_link_libraries(mpi_interop Legion::Legion ${MPI_CXX_LIBRARIES})
+target_include_directories(mpi_interop PRIVATE ${MPI_C_INCLUDE_PATH})
 if(Legion_ENABLE_TESTING)
   add_test(NAME mpi_interop COMMAND $<TARGET_FILE:mpi_interop>)
 endif()


### PR DESCRIPTION
`mpi_interop` actively makes use of MPI, so link it against it.