### PR TITLE
realm: allow uthread default override

### DIFF
--- a/runtime/realm/realm_config.h
+++ b/runtime/realm/realm_config.h
@@ -21,7 +21,7 @@
 
 // if set, uses ucontext.h for user level thread switching, otherwise falls
 //  back to POSIX threads
-#ifndef __MACH__
+#if !defined(REALM_USE_NATIVE_THREADS) && !defined(__MACH__)
 // clang on Mac is generating apparently-broken code in the user thread
 //  scheduler, so disable this code path for now
 #define REALM_USE_USER_THREADS


### PR DESCRIPTION
The JVM does not take kindly to non-native threads.

Signed-off-by: Noah Watkins <noahwatkins@gmail.com>