### PR TITLE
Static-link Legion into compiled Regent programs

### DIFF
--- a/bindings/terra/.gitignore
+++ b/bindings/terra/.gitignore
@@ -1,3 +1,4 @@
 *.a
 *.so
 *.dylib
+link_flags.txt

--- a/bindings/terra/Makefile
+++ b/bindings/terra/Makefile
@@ -78,6 +78,10 @@ endif
 CC_FLAGS += -DREALM_ALLOW_MISSING_LLVM_LIBS
 $(OUTFILE) : LLVM_LIBS=
 
+# Also static-link all application objects
+OUTLIB = liblegion_terra_bindings.a
+OUTLINK_FLAGS = link_flags.txt
+
 ###########################################################################
 #
 #   Don't change anything below here

--- a/language/src/regent/std_base.t
+++ b/language/src/regent/std_base.t
@@ -25,7 +25,6 @@ base.config, base.args = config.args()
 -- ## Legion Bindings
 -- #################
 
-terralib.linklibrary("liblegion_terra.so")
 local c = terralib.includecstring([[
 #include "legion_c.h"
 #include "legion_terra.h"


### PR DESCRIPTION
This is really a proof-of-concept. There's definitely a cleaner way to propagate linking information to the Regent compiler. Also, this won't pass the test suite as-is.

With these changes, circuit (with SAVEOBJ=1) and soleil-x (without a custom mapper) compile and run correctly, and without dynamic-linking libsoleil_terra.so. I've tested this locally and on Titan.

I've tried to avoid dynamic-linking during compilation as well. This should only be necessary if you want to run the code on-the-fly instead of emitting an executable (which is why I do terralib.linklibrary in regentlib.start), or want to use functions from Legion during compilation (which is what happens in the test suite, and in -fdebug 1 mode, both of which use at least the timer code from Legion).