### PR TITLE
Support compilation with CUDA on head nodes w/o a GPU

### DIFF
--- a/language/regent.py
+++ b/language/regent.py
@@ -79,6 +79,7 @@ if os_name == 'Darwin':
 lib_path = (
     (os.environ[LD_LIBRARY_PATH].split(':')
      if LD_LIBRARY_PATH in os.environ else []) +
+    ([os.path.join(cuda_dir, 'lib64', 'stubs')] if cuda_dir else []) +
     [os.path.join(terra_dir, 'build'),
      (os.path.join(cmake_build_dir, 'lib') if cmake else bindings_dir)])
 

--- a/language/src/regent/std.t
+++ b/language/src/regent/std.t
@@ -3389,7 +3389,6 @@ function std.setup(main_task, extra_setup_thunk, task_wrappers, registration_nam
     end)
   local cuda_setup = quote end
   if std.config["cuda"] and cudahelper.check_cuda_available() then
-    cudahelper.link_driver_library()
     local all_kernels = {}
     variants:map(function(variant)
       if variant:is_cuda() then

--- a/language/src/regent/std_base.t
+++ b/language/src/regent/std_base.t
@@ -15,6 +15,7 @@
 -- Regent Standard Library - Base Layer
 
 local config = require("regent/config")
+local cudahelper = require("regent/cudahelper")
 local data = require("common/data")
 
 local base = {}
@@ -25,6 +26,13 @@ base.config, base.args = config.args()
 -- ## Legion Bindings
 -- #################
 
+if config["cuda"] and cudahelper.check_cuda_available() then
+  -- Terralib.linklibrary only seems to consider LD_LIBRARY_PATH when linking a
+  -- dynamic library directly, and not when trying to find the libraries that
+  -- it depends on, so we load libcuda.so preemptively, before libregent.so
+  -- requests it.
+  cudahelper.link_driver_library()
+end
 terralib.linklibrary("libregent.so")
 local c = terralib.includecstring([[
 #include "legion.h"

--- a/language/src/regent/std_base.t
+++ b/language/src/regent/std_base.t
@@ -26,13 +26,6 @@ base.config, base.args = config.args()
 -- ## Legion Bindings
 -- #################
 
-if config["cuda"] and cudahelper.check_cuda_available() then
-  -- Terralib.linklibrary only seems to consider LD_LIBRARY_PATH when linking a
-  -- dynamic library directly, and not when trying to find the libraries that
-  -- it depends on, so we load libcuda.so preemptively, before libregent.so
-  -- requests it.
-  cudahelper.link_driver_library()
-end
 terralib.linklibrary("libregent.so")
 local c = terralib.includecstring([[
 #include "legion.h"

--- a/runtime/runtime.mk
+++ b/runtime/runtime.mk
@@ -305,7 +305,7 @@ endif
 ifeq ($(strip $(DARWIN)),1)
 LEGION_LD_FLAGS	+= -L$(CUDA)/lib -lcuda
 else
-LEGION_LD_FLAGS	+= -L$(CUDA)/lib64 -lcuda -Xlinker -rpath=$(CUDA)/lib64
+LEGION_LD_FLAGS	+= -L$(CUDA)/lib64 -L$(CUDA)/lib64/stubs -lcuda -Xlinker -rpath=$(CUDA)/lib64
 endif
 # CUDA arch variables
 ifeq ($(strip $(GPU_ARCH)),fermi)


### PR DESCRIPTION
When building with CUDA on a head node w/o a GPU, libcuda.so will not be found
in /usr/lib, but a stub will exist in $CUDA_HOME/lib64/stubs. We need to add an
explicit pointer to that file when building Regent (in runtime.mk), and also
when linking a Regent program with libregent.so (in regent.py).

The final executable will not contain a direct pointer to this stub libcuda.so.
It will instead list a dependency on SONAME=libcuda.so.1. When we actually run
it on a node with a GPU, the real libcuda.so library will exist in /usr/lib, and
the dynamic linker should be able to locate it.