### PR TITLE
Make optimize_config_options pass 10x faster

### DIFF
--- a/bindings/python/examples/index_launch.py
+++ b/bindings/python/examples/index_launch.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+# Copyright 2018 Stanford University
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import print_function
+
+import legion
+from legion import task
+
+@task
+def hi(i):
+    print("hello %s" % i)
+
+@task(top_level=True)
+def main():
+    for i in legion.IndexLaunch([10]):
+        hi(i)

--- a/bindings/python/examples/index_launch.py
+++ b/bindings/python/examples/index_launch.py
@@ -23,8 +23,12 @@ from legion import task
 @task
 def hi(i):
     print("hello %s" % i)
+    return i
 
 @task(top_level=True)
 def main():
+    futures = []
     for i in legion.IndexLaunch([10]):
-        hi(i)
+        futures.append(hi(i))
+    for future in futures:
+        print("got %s" % future.get())

--- a/language/scripts/setup_env.py
+++ b/language/scripts/setup_env.py
@@ -21,6 +21,8 @@ import argparse, hashlib, multiprocessing, os, platform, re, subprocess, sys, tr
 def discover_llvm_version():
     if platform.node().startswith('titan'):
         return '38'
+    elif os.environ.get('LMOD_SYSTEM_NAME') == 'summit': # Summit doesn't set hostname
+        return '38'
     else:
         return '39'
 
@@ -43,6 +45,8 @@ def discover_conduit():
         return 'psm'
     elif platform.node().startswith('titan'):
         return 'gemini'
+    elif os.environ.get('LMOD_SYSTEM_NAME') == 'summit': # Summit doesn't set hostname
+        return 'ibv'
     else:
         raise Exception('Please set CONDUIT in your environment')
 

--- a/language/scripts/setup_env.py
+++ b/language/scripts/setup_env.py
@@ -50,6 +50,12 @@ def discover_conduit():
     else:
         raise Exception('Please set CONDUIT in your environment')
 
+def gasnet_enabled():
+    return not ('USE_GASNET' in os.environ and os.environ['USE_GASNET'] == '0')
+
+def hdf_enabled():
+    return 'USE_HDF' in os.environ and os.environ['USE_HDF'] == '1'
+
 def check_sha1(file_path, sha1):
     with open(file_path, 'rb') as f:
         assert hashlib.sha1(f.read()).hexdigest() == sha1
@@ -142,14 +148,35 @@ def build_terra(terra_dir, llvm_dir, cache, is_cray, thread_count):
         cwd=terra_dir,
         env=env)
 
+def build_hdf(source_dir, install_dir, thread_count, is_cray):
+    env = None
+    if is_cray:
+        env = dict(list(os.environ.items()) + [
+            ('CC', os.environ['HOST_CC']),
+            ('CXX', os.environ['HOST_CXX']),
+        ])
+    subprocess.check_call(
+        ['./configure',
+         '--prefix=%s' % install_dir,
+         '--enable-threadsafe',
+         '--disable-hl'],
+        cwd=source_dir,
+        env=env)
+    subprocess.check_call(['make', '-j', str(thread_count)], cwd=source_dir)
+    subprocess.check_call(['make', 'install'], cwd=source_dir)
+
 def build_regent(root_dir, use_cmake, cmake_exe,
-                 gasnet_dir, llvm_dir, terra_dir, conduit, thread_count):
-    env = dict(list(os.environ.items()) + [
-        ('CONDUIT', conduit),
-        ('GASNET', gasnet_dir),
-        ('USE_GASNET', os.environ['USE_GASNET'] if 'USE_GASNET' in os.environ else '1'),
-        ('LLVM_CONFIG', os.path.join(llvm_dir, 'bin', 'llvm-config')),
-    ])
+                 gasnet_dir, llvm_dir, terra_dir, hdf_dir, conduit, thread_count):
+    env = dict(list(os.environ.items()) +
+        ([('CONDUIT', conduit),
+          ('GASNET', gasnet_dir),
+          ('USE_GASNET', '1')]
+         if gasnet_enabled() else []) +
+        ([('HDF_ROOT', hdf_dir),
+          ('USE_HDF', '1')]
+         if hdf_enabled() else []) +
+        [('LLVM_CONFIG', os.path.join(llvm_dir, 'bin', 'llvm-config'))]
+    )
 
     subprocess.check_call(
         [os.path.join(root_dir, 'install.py'),
@@ -200,6 +227,19 @@ def install_llvm(llvm_dir, llvm_install_dir, llvm_version, llvm_use_cmake, cmake
         os.mkdir(llvm_build_dir)
         os.mkdir(llvm_install_dir)
         build_llvm(llvm_source_dir, llvm_build_dir, llvm_install_dir, llvm_use_cmake, cmake_exe, thread_count, is_cray)
+
+def install_hdf(hdf_dir, hdf_install_dir, thread_count, cache, is_cray, insecure):
+    try:
+        os.mkdir(hdf_dir)
+    except OSError:
+        pass # Hope this means it already exists
+    assert(os.path.isdir(hdf_dir))
+    hdf_tarball = os.path.join(hdf_dir, 'hdf5-1.10.1.tar.gz')
+    hdf_source_dir = os.path.join(hdf_dir, 'hdf5-1.10.1')
+    download(hdf_tarball, 'http://sapling.stanford.edu/~manolis/hdf/hdf5-1.10.1.tar.gz', '73b77a23ca099ac47d8241f633bf67430007c430', insecure=insecure)
+    if not cache:
+        extract(hdf_dir, hdf_tarball, 'gz')
+        build_hdf(hdf_source_dir, hdf_install_dir, thread_count, is_cray)
 
 def print_advice(component_dir):
     print('Given the number of things that could potentially have gone')
@@ -290,23 +330,26 @@ def driver(prefix_dir=None, cache=False, legion_use_cmake=False, llvm_version=No
 
     thread_count = multiprocessing.cpu_count()
 
-    gasnet_dir = os.path.realpath(os.path.join(prefix_dir, 'gasnet'))
-    if not os.path.exists(gasnet_dir):
-        git_clone(gasnet_dir, 'https://github.com/StanfordLegion/gasnet.git')
-    if not cache:
-        conduit = discover_conduit()
-        gasnet_release_dir = os.path.join(gasnet_dir, 'release')
-        gasnet_build_result = os.path.join(
-            gasnet_release_dir, '%s-conduit' % conduit,
-            'libgasnet-%s-par.a' % conduit)
-        if not os.path.exists(gasnet_release_dir):
-            try:
-                build_gasnet(gasnet_dir, conduit)
-            except Exception as e:
-                report_build_failure('gasnet', gasnet_dir, e)
-        else:
-            check_dirty_build('gasnet', gasnet_build_result, gasnet_dir)
-        assert os.path.exists(gasnet_build_result)
+    gasnet_release_dir = None
+    conduit = None
+    if gasnet_enabled():
+        gasnet_dir = os.path.realpath(os.path.join(prefix_dir, 'gasnet'))
+        if not os.path.exists(gasnet_dir):
+            git_clone(gasnet_dir, 'https://github.com/StanfordLegion/gasnet.git')
+        if not cache:
+            conduit = discover_conduit()
+            gasnet_release_dir = os.path.join(gasnet_dir, 'release')
+            gasnet_build_result = os.path.join(
+                gasnet_release_dir, '%s-conduit' % conduit,
+                'libgasnet-%s-par.a' % conduit)
+            if not os.path.exists(gasnet_release_dir):
+                try:
+                    build_gasnet(gasnet_dir, conduit)
+                except Exception as e:
+                    report_build_failure('gasnet', gasnet_dir, e)
+            else:
+                check_dirty_build('gasnet', gasnet_build_result, gasnet_dir)
+            assert os.path.exists(gasnet_build_result)
 
     cmake_exe = None
     try:
@@ -365,9 +408,24 @@ def driver(prefix_dir=None, cache=False, legion_use_cmake=False, llvm_version=No
     if not cache:
         assert os.path.exists(terra_build_result)
 
+    hdf_install_dir = None
+    if hdf_enabled():
+        hdf_dir = os.path.join(prefix_dir, 'hdf')
+        hdf_install_dir = os.path.join(hdf_dir, 'install')
+        hdf_build_result = os.path.join(hdf_install_dir, 'lib', 'libhdf5.so')
+        if not os.path.exists(hdf_install_dir):
+            try:
+                install_hdf(hdf_dir, hdf_install_dir, thread_count, cache, is_cray, insecure)
+            except Exception as e:
+                report_build_failure('hdf', hdf_dir, e)
+        else:
+            check_dirty_build('hdf', hdf_build_result, hdf_dir)
+        if not cache:
+            assert os.path.exists(hdf_build_result)
+
     if not cache:
         build_regent(root_dir, legion_use_cmake, cmake_exe,
-                     gasnet_release_dir, llvm_install_dir, terra_dir,
+                     gasnet_release_dir, llvm_install_dir, terra_dir, hdf_install_dir,
                      conduit, thread_count)
 
 if __name__ == '__main__':

--- a/language/scripts/setup_env.py
+++ b/language/scripts/setup_env.py
@@ -51,7 +51,7 @@ def discover_conduit():
         raise Exception('Please set CONDUIT in your environment')
 
 def gasnet_enabled():
-    return not ('USE_GASNET' in os.environ and os.environ['USE_GASNET'] == '0')
+    return 'USE_GASNET' not in os.environ or os.environ['USE_GASNET'] == '1'
 
 def hdf_enabled():
     return 'USE_HDF' in os.environ and os.environ['USE_HDF'] == '1'

--- a/language/src/regent/cudahelper.t
+++ b/language/src/regent/cudahelper.t
@@ -82,8 +82,8 @@ local terra has_symbol(symbol : rawstring)
 end
 
 do
-  if has_symbol("cuInit") then
-    if not config["cuda-offline"]  then
+  if not config["cuda-offline"] then
+    if has_symbol("cuInit") then
       local r = DriverAPI.cuInit(0)
       assert(r == 0)
       terra cudahelper.check_cuda_available()
@@ -91,12 +91,12 @@ do
       end
     else
       terra cudahelper.check_cuda_available()
-        return true
+        return false
       end
     end
   else
     terra cudahelper.check_cuda_available()
-      return false
+      return true
     end
   end
 end

--- a/language/src/regent/optimize_config_options.t
+++ b/language/src/regent/optimize_config_options.t
@@ -28,6 +28,14 @@ local data = require("common/data")
 local report = require("common/report")
 local std = require("regent/std")
 
+local function always_true(node)
+  return true
+end
+
+local function always_false(node)
+  return false
+end
+
 local context = {}
 
 function context:__index (field)
@@ -47,104 +55,103 @@ function context.new_global_scope()
   return setmetatable(cx, context)
 end
 
+local typed_node_is_leaf = {
+  -- Expressions:
+  [ast.typed.expr.Call] = function(node)
+    return not std.is_task(node.fn.value)
+  end,
+
+  [ast.typed.expr.RawContext]                 = always_false,
+  [ast.typed.expr.Ispace]                     = always_false,
+  [ast.typed.expr.Region]                     = always_false,
+  [ast.typed.expr.Partition]                  = always_false,
+  [ast.typed.expr.PartitionEqual]             = always_false,
+  [ast.typed.expr.PartitionByField]           = always_false,
+  [ast.typed.expr.Image]                      = always_false,
+  [ast.typed.expr.Preimage]                   = always_false,
+  [ast.typed.expr.CrossProduct]               = always_false,
+  [ast.typed.expr.CrossProductArray]          = always_false,
+  [ast.typed.expr.ListSlicePartition]         = always_false,
+  [ast.typed.expr.ListDuplicatePartition]     = always_false,
+  [ast.typed.expr.ListSliceCrossProduct]      = always_false,
+  [ast.typed.expr.ListCrossProduct]           = always_false,
+  [ast.typed.expr.ListCrossProductComplete]   = always_false,
+  [ast.typed.expr.ListPhaseBarriers]          = always_false,
+  [ast.typed.expr.PhaseBarrier]               = always_false,
+  [ast.typed.expr.DynamicCollective]          = always_false,
+  [ast.typed.expr.DynamicCollectiveGetResult] = always_false,
+  [ast.typed.expr.Advance]                    = always_false,
+  [ast.typed.expr.Adjust]                     = always_false,
+  [ast.typed.expr.Arrive]                     = always_false,
+  [ast.typed.expr.Await]                      = always_false,
+  [ast.typed.expr.Copy]                       = always_false,
+  [ast.typed.expr.Fill]                       = always_false,
+  [ast.typed.expr.Acquire]                    = always_false,
+  [ast.typed.expr.Release]                    = always_false,
+  [ast.typed.expr.AttachHDF5]                 = always_false,
+  [ast.typed.expr.DetachHDF5]                 = always_false,
+  [ast.typed.expr.AllocateScratchFields]      = always_false,
+  [ast.typed.expr.WithScratchFields]          = always_false,
+  [ast.typed.expr.RegionRoot]                 = always_false,
+  [ast.typed.expr.Condition]                  = always_false,
+  [ast.typed.expr.Future]                     = always_false,
+  [ast.typed.expr.FutureGetResult]            = always_false,
+
+  [ast.typed.expr.ID]              = always_true,
+  [ast.typed.expr.Constant]        = always_true,
+  [ast.typed.expr.Function]        = always_true,
+  [ast.typed.expr.FieldAccess]     = always_true,
+  [ast.typed.expr.IndexAccess]     = always_true,
+  [ast.typed.expr.MethodCall]      = always_true,
+  [ast.typed.expr.Cast]            = always_true,
+  [ast.typed.expr.Ctor]            = always_true,
+  [ast.typed.expr.CtorListField]   = always_true,
+  [ast.typed.expr.CtorRecField]    = always_true,
+  [ast.typed.expr.RawFields]       = always_true,
+  [ast.typed.expr.RawPhysical]     = always_true,
+  [ast.typed.expr.RawRuntime]      = always_true,
+  [ast.typed.expr.RawValue]        = always_true,
+  [ast.typed.expr.Isnull]          = always_true,
+  [ast.typed.expr.Null]            = always_true,
+  [ast.typed.expr.DynamicCast]     = always_true,
+  [ast.typed.expr.StaticCast]      = always_true,
+  [ast.typed.expr.UnsafeCast]      = always_true,
+  [ast.typed.expr.ListInvert]      = always_true,
+  [ast.typed.expr.ListRange]       = always_true,
+  [ast.typed.expr.ListIspace]      = always_true,
+  [ast.typed.expr.ListFromElement] = always_true,
+  [ast.typed.expr.Unary]           = always_true,
+  [ast.typed.expr.Binary]          = always_true,
+  [ast.typed.expr.Deref]           = always_true,
+
+  -- Statements:
+  [ast.typed.stat.MustEpoch]       = always_false,
+  [ast.typed.stat.IndexLaunchNum]  = always_false,
+  [ast.typed.stat.IndexLaunchList] = always_false,
+  [ast.typed.stat.RawDelete]       = always_false,
+  [ast.typed.stat.Fence]           = always_false,
+
+  [ast.typed.stat.If]         = always_true,
+  [ast.typed.stat.Elseif]     = always_true,
+  [ast.typed.stat.While]      = always_true,
+  [ast.typed.stat.ForNum]     = always_true,
+  [ast.typed.stat.ForList]    = always_true,
+  [ast.typed.stat.Repeat]     = always_true,
+  [ast.typed.stat.Block]      = always_true,
+  [ast.typed.stat.Var]        = always_true,
+  [ast.typed.stat.VarUnpack]  = always_true,
+  [ast.typed.stat.Return]     = always_true,
+  [ast.typed.stat.Break]      = always_true,
+  [ast.typed.stat.Assignment] = always_true,
+  [ast.typed.stat.Reduce]     = always_true,
+  [ast.typed.stat.Expr]       = always_true,
+}
+
 local function analyze_leaf_node(cx)
   return function(node)
-    -- Expressions:
-    if node:is(ast.typed.expr.Call) then
-      return not std.is_task(node.fn.value)
-
-    elseif node:is(ast.typed.expr.RawContext) or
-      node:is(ast.typed.expr.Ispace) or
-      node:is(ast.typed.expr.Region) or
-      node:is(ast.typed.expr.Partition) or
-      node:is(ast.typed.expr.PartitionEqual) or
-      node:is(ast.typed.expr.PartitionByField) or
-      node:is(ast.typed.expr.Image) or
-      node:is(ast.typed.expr.Preimage) or
-      node:is(ast.typed.expr.CrossProduct) or
-      node:is(ast.typed.expr.CrossProductArray) or
-      node:is(ast.typed.expr.ListSlicePartition) or
-      node:is(ast.typed.expr.ListDuplicatePartition) or
-      node:is(ast.typed.expr.ListSliceCrossProduct) or
-      node:is(ast.typed.expr.ListCrossProduct) or
-      node:is(ast.typed.expr.ListCrossProductComplete) or
-      node:is(ast.typed.expr.ListPhaseBarriers) or
-      node:is(ast.typed.expr.PhaseBarrier) or
-      node:is(ast.typed.expr.DynamicCollective) or
-      node:is(ast.typed.expr.DynamicCollectiveGetResult) or
-      node:is(ast.typed.expr.Advance) or
-      node:is(ast.typed.expr.Adjust) or
-      node:is(ast.typed.expr.Arrive) or
-      node:is(ast.typed.expr.Await) or
-      node:is(ast.typed.expr.Copy) or
-      node:is(ast.typed.expr.Fill) or
-      node:is(ast.typed.expr.Acquire) or
-      node:is(ast.typed.expr.Release) or
-      node:is(ast.typed.expr.AttachHDF5) or
-      node:is(ast.typed.expr.DetachHDF5) or
-      node:is(ast.typed.expr.AllocateScratchFields) or
-      node:is(ast.typed.expr.WithScratchFields) or
-      node:is(ast.typed.expr.RegionRoot) or
-      node:is(ast.typed.expr.Condition) or
-      node:is(ast.typed.expr.Future) or
-      node:is(ast.typed.expr.FutureGetResult)
-    then
-      return false
-
-    elseif node:is(ast.typed.expr.ID) or
-      node:is(ast.typed.expr.Constant) or
-      node:is(ast.typed.expr.Function) or
-      node:is(ast.typed.expr.FieldAccess) or
-      node:is(ast.typed.expr.IndexAccess) or
-      node:is(ast.typed.expr.MethodCall) or
-      node:is(ast.typed.expr.Cast) or
-      node:is(ast.typed.expr.Ctor) or
-      node:is(ast.typed.expr.CtorListField) or
-      node:is(ast.typed.expr.CtorRecField) or
-      node:is(ast.typed.expr.RawFields) or
-      node:is(ast.typed.expr.RawPhysical) or
-      node:is(ast.typed.expr.RawRuntime) or
-      node:is(ast.typed.expr.RawValue) or
-      node:is(ast.typed.expr.Isnull) or
-      node:is(ast.typed.expr.Null) or
-      node:is(ast.typed.expr.DynamicCast) or
-      node:is(ast.typed.expr.StaticCast) or
-      node:is(ast.typed.expr.UnsafeCast) or
-      node:is(ast.typed.expr.ListInvert) or
-      node:is(ast.typed.expr.ListRange) or
-      node:is(ast.typed.expr.ListIspace) or
-      node:is(ast.typed.expr.ListFromElement) or
-      node:is(ast.typed.expr.Unary) or
-      node:is(ast.typed.expr.Binary) or
-      node:is(ast.typed.expr.Deref)
-    then
-      return true
-
-    -- Statements:
-    elseif node:is(ast.typed.stat.MustEpoch) or
-      node:is(ast.typed.stat.IndexLaunchNum) or
-      node:is(ast.typed.stat.IndexLaunchList) or
-      node:is(ast.typed.stat.RawDelete) or
-      node:is(ast.typed.stat.Fence)
-    then
-      return false
-
-    elseif node:is(ast.typed.stat.If) or
-      node:is(ast.typed.stat.Elseif) or
-      node:is(ast.typed.stat.While) or
-      node:is(ast.typed.stat.ForNum) or
-      node:is(ast.typed.stat.ForList) or
-      node:is(ast.typed.stat.Repeat) or
-      node:is(ast.typed.stat.Block) or
-      node:is(ast.typed.stat.Var) or
-      node:is(ast.typed.stat.VarUnpack) or
-      node:is(ast.typed.stat.Return) or
-      node:is(ast.typed.stat.Break) or
-      node:is(ast.typed.stat.Assignment) or
-      node:is(ast.typed.stat.Reduce) or
-      node:is(ast.typed.stat.Expr)
-    then
-      return true
+    -- Typed AST leaf nodes:
+    if typed_node_is_leaf[node.node_type] then
+      return typed_node_is_leaf[node.node_type](node)
 
     -- Miscellaneous:
     elseif node:is(ast.typed.Block) or
@@ -170,103 +177,104 @@ local function analyze_leaf(cx, node)
     node, true)
 end
 
+local typed_node_is_inner = {
+  -- Expressions:
+  [ast.typed.expr.Deref] = function(node)
+    return not std.is_ref(node.expr_type)
+  end,
+  [ast.typed.expr.IndexAccess] = function(node)
+    return not std.is_ref(node.expr_type)
+  end,
+
+  [ast.typed.expr.RawPhysical] = always_false,
+  [ast.typed.expr.Adjust]      = always_false,
+  [ast.typed.expr.Arrive]      = always_false,
+  [ast.typed.expr.Await]       = always_false,
+
+  [ast.typed.expr.ID]                         = always_true,
+  [ast.typed.expr.Constant]                   = always_true,
+  [ast.typed.expr.Function]                   = always_true,
+  [ast.typed.expr.FieldAccess]                = always_true,
+  [ast.typed.expr.MethodCall]                 = always_true,
+  [ast.typed.expr.Call]                       = always_true,
+  [ast.typed.expr.Cast]                       = always_true,
+  [ast.typed.expr.Ctor]                       = always_true,
+  [ast.typed.expr.CtorListField]              = always_true,
+  [ast.typed.expr.CtorRecField]               = always_true,
+  [ast.typed.expr.RawContext]                 = always_true,
+  [ast.typed.expr.RawFields]                  = always_true,
+  [ast.typed.expr.RawRuntime]                 = always_true,
+  [ast.typed.expr.RawValue]                   = always_true,
+  [ast.typed.expr.Isnull]                     = always_true,
+  [ast.typed.expr.Null]                       = always_true,
+  [ast.typed.expr.DynamicCast]                = always_true,
+  [ast.typed.expr.StaticCast]                 = always_true,
+  [ast.typed.expr.UnsafeCast]                 = always_true,
+  [ast.typed.expr.Ispace]                     = always_true,
+  [ast.typed.expr.Ispace]                     = always_true,
+  [ast.typed.expr.Region]                     = always_true,
+  [ast.typed.expr.Partition]                  = always_true,
+  [ast.typed.expr.PartitionEqual]             = always_true,
+  [ast.typed.expr.PartitionByField]           = always_true,
+  [ast.typed.expr.Image]                      = always_true,
+  [ast.typed.expr.Preimage]                   = always_true,
+  [ast.typed.expr.CrossProduct]               = always_true,
+  [ast.typed.expr.CrossProductArray]          = always_true,
+  [ast.typed.expr.ListSlicePartition]         = always_true,
+  [ast.typed.expr.ListDuplicatePartition]     = always_true,
+  [ast.typed.expr.ListSliceCrossProduct]      = always_true,
+  [ast.typed.expr.ListCrossProduct]           = always_true,
+  [ast.typed.expr.ListCrossProductComplete]   = always_true,
+  [ast.typed.expr.ListPhaseBarriers]          = always_true,
+  [ast.typed.expr.ListInvert]                 = always_true,
+  [ast.typed.expr.ListRange]                  = always_true,
+  [ast.typed.expr.ListIspace]                 = always_true,
+  [ast.typed.expr.ListFromElement]            = always_true,
+  [ast.typed.expr.PhaseBarrier]               = always_true,
+  [ast.typed.expr.DynamicCollective]          = always_true,
+  [ast.typed.expr.DynamicCollectiveGetResult] = always_true,
+  [ast.typed.expr.Advance]                    = always_true,
+  [ast.typed.expr.Copy]                       = always_true,
+  [ast.typed.expr.Fill]                       = always_true,
+  [ast.typed.expr.Acquire]                    = always_true,
+  [ast.typed.expr.Release]                    = always_true,
+  [ast.typed.expr.AttachHDF5]                 = always_true,
+  [ast.typed.expr.DetachHDF5]                 = always_true,
+  [ast.typed.expr.AllocateScratchFields]      = always_true,
+  [ast.typed.expr.WithScratchFields]          = always_true,
+  [ast.typed.expr.RegionRoot]                 = always_true,
+  [ast.typed.expr.Condition]                  = always_true,
+  [ast.typed.expr.Unary]                      = always_true,
+  [ast.typed.expr.Binary]                     = always_true,
+  [ast.typed.expr.Future]                     = always_true,
+  [ast.typed.expr.FutureGetResult]            = always_true,
+  -- Statements:
+  [ast.typed.stat.If]              = always_true,
+  [ast.typed.stat.Elseif]          = always_true,
+  [ast.typed.stat.While]           = always_true,
+  [ast.typed.stat.ForNum]          = always_true,
+  [ast.typed.stat.ForList]         = always_true,
+  [ast.typed.stat.Repeat]          = always_true,
+  [ast.typed.stat.MustEpoch]       = always_true,
+  [ast.typed.stat.Block]           = always_true,
+  [ast.typed.stat.IndexLaunchNum]  = always_true,
+  [ast.typed.stat.IndexLaunchList] = always_true,
+  [ast.typed.stat.Var]             = always_true,
+  [ast.typed.stat.VarUnpack]       = always_true,
+  [ast.typed.stat.Return]          = always_true,
+  [ast.typed.stat.Break]           = always_true,
+  [ast.typed.stat.Assignment]      = always_true,
+  [ast.typed.stat.Reduce]          = always_true,
+  [ast.typed.stat.Expr]            = always_true,
+  [ast.typed.stat.RawDelete]       = always_true,
+  [ast.typed.stat.Fence]           = always_true,
+}
+
 local function analyze_inner_node(cx)
   return function(node)
-    -- Expressions:
-    if node:is(ast.typed.expr.Deref) or
-      node:is(ast.typed.expr.IndexAccess)
-    then
-      return not std.is_ref(node.expr_type)
-
-    elseif node:is(ast.typed.expr.RawPhysical) or
-      node:is(ast.typed.expr.Adjust) or
-      node:is(ast.typed.expr.Arrive) or
-      node:is(ast.typed.expr.Await)
-    then
-      return false
-
-    elseif node:is(ast.typed.expr.ID) or
-      node:is(ast.typed.expr.Constant) or
-      node:is(ast.typed.expr.Function) or
-      node:is(ast.typed.expr.FieldAccess) or
-      node:is(ast.typed.expr.MethodCall) or
-      node:is(ast.typed.expr.Call) or
-      node:is(ast.typed.expr.Cast) or
-      node:is(ast.typed.expr.Ctor) or
-      node:is(ast.typed.expr.CtorListField) or
-      node:is(ast.typed.expr.CtorRecField) or
-      node:is(ast.typed.expr.RawContext) or
-      node:is(ast.typed.expr.RawFields) or
-      node:is(ast.typed.expr.RawRuntime) or
-      node:is(ast.typed.expr.RawValue) or
-      node:is(ast.typed.expr.Isnull) or
-      node:is(ast.typed.expr.Null) or
-      node:is(ast.typed.expr.DynamicCast) or
-      node:is(ast.typed.expr.StaticCast) or
-      node:is(ast.typed.expr.UnsafeCast) or
-      node:is(ast.typed.expr.Ispace) or
-      node:is(ast.typed.expr.Ispace) or
-      node:is(ast.typed.expr.Region) or
-      node:is(ast.typed.expr.Partition) or
-      node:is(ast.typed.expr.PartitionEqual) or
-      node:is(ast.typed.expr.PartitionByField) or
-      node:is(ast.typed.expr.Image) or
-      node:is(ast.typed.expr.Preimage) or
-      node:is(ast.typed.expr.CrossProduct) or
-      node:is(ast.typed.expr.CrossProductArray) or
-      node:is(ast.typed.expr.ListSlicePartition) or
-      node:is(ast.typed.expr.ListDuplicatePartition) or
-      node:is(ast.typed.expr.ListSliceCrossProduct) or
-      node:is(ast.typed.expr.ListCrossProduct) or
-      node:is(ast.typed.expr.ListCrossProductComplete) or
-      node:is(ast.typed.expr.ListPhaseBarriers) or
-      node:is(ast.typed.expr.ListInvert) or
-      node:is(ast.typed.expr.ListRange) or
-      node:is(ast.typed.expr.ListIspace) or
-      node:is(ast.typed.expr.ListFromElement) or
-      node:is(ast.typed.expr.PhaseBarrier) or
-      node:is(ast.typed.expr.DynamicCollective) or
-      node:is(ast.typed.expr.DynamicCollectiveGetResult) or
-      node:is(ast.typed.expr.Advance) or
-      node:is(ast.typed.expr.Copy) or
-      node:is(ast.typed.expr.Fill) or
-      node:is(ast.typed.expr.Acquire) or
-      node:is(ast.typed.expr.Release) or
-      node:is(ast.typed.expr.AttachHDF5) or
-      node:is(ast.typed.expr.DetachHDF5) or
-      node:is(ast.typed.expr.AllocateScratchFields) or
-      node:is(ast.typed.expr.WithScratchFields) or
-      node:is(ast.typed.expr.RegionRoot) or
-      node:is(ast.typed.expr.Condition) or
-      node:is(ast.typed.expr.Unary) or
-      node:is(ast.typed.expr.Binary) or
-      node:is(ast.typed.expr.Future) or
-      node:is(ast.typed.expr.FutureGetResult)
-    then
-      return true
-
-    -- Statements:
-    elseif node:is(ast.typed.stat.If) or
-      node:is(ast.typed.stat.Elseif) or
-      node:is(ast.typed.stat.While) or
-      node:is(ast.typed.stat.ForNum) or
-      node:is(ast.typed.stat.ForList) or
-      node:is(ast.typed.stat.Repeat) or
-      node:is(ast.typed.stat.MustEpoch) or
-      node:is(ast.typed.stat.Block) or
-      node:is(ast.typed.stat.IndexLaunchNum) or
-      node:is(ast.typed.stat.IndexLaunchList) or
-      node:is(ast.typed.stat.Var) or
-      node:is(ast.typed.stat.VarUnpack) or
-      node:is(ast.typed.stat.Return) or
-      node:is(ast.typed.stat.Break) or
-      node:is(ast.typed.stat.Assignment) or
-      node:is(ast.typed.stat.Reduce) or
-      node:is(ast.typed.stat.Expr) or
-      node:is(ast.typed.stat.RawDelete) or
-      node:is(ast.typed.stat.Fence)
-    then
-      return true
+    -- Typed AST leaf nodes:
+    if typed_node_is_inner[node.node_type] then
+      return typed_node_is_inner[node.node_type](node)
 
     -- Miscellaneous:
     elseif node:is(ast.typed.Block) or

--- a/language/src/regent/std.t
+++ b/language/src/regent/std.t
@@ -3901,7 +3901,7 @@ end
 do
   local intrinsic_names = {}
   if os.execute("bash -c \"[ `uname` == 'Linux' ]\"") == 0 and
-    os.execute("grep POWER8 /proc/cpuinfo > /dev/null") == 0
+    os.execute("grep altivec /proc/cpuinfo > /dev/null") == 0
   then
     intrinsic_names[vector(float,  4)] = "llvm.ppc.altivec.v%sfp"
     intrinsic_names[vector(double, 2)] = "llvm.ppc.vsx.xv%sdp"

--- a/language/src/regent/vectorize_loops.t
+++ b/language/src/regent/vectorize_loops.t
@@ -43,7 +43,7 @@ else
     SIMD_REG_SIZE = 32
   elseif os.execute("grep sse /proc/cpuinfo > /dev/null") == 0 then
     SIMD_REG_SIZE = 16
-  elseif os.execute("grep POWER8 /proc/cpuinfo > /dev/null") == 0 then
+  elseif os.execute("grep altivec /proc/cpuinfo > /dev/null") == 0 then
     SIMD_REG_SIZE = 16
   else
     error("Unable to determine CPU architecture")

--- a/language/test.py
+++ b/language/test.py
@@ -414,7 +414,6 @@ def test_driver(argv):
                         dest='openmp')
     parser.add_argument('--extra',
                         action='append',
-                        required=False,
                         default=[],
                         help='extra flags to use for each test',
                         dest='extra_flags')

--- a/runtime/legion/legion_c.cc
+++ b/runtime/legion/legion_c.cc
@@ -2263,6 +2263,15 @@ legion_future_get_untyped_size(legion_future_t handle_)
 // Future Map Operations
 // -----------------------------------------------------------------------
 
+legion_future_map_t
+legion_future_map_copy(legion_future_map_t handle_)
+{
+  FutureMap *handle = CObjectWrapper::unwrap(handle_);
+
+  FutureMap *result = new FutureMap(*handle);
+  return CObjectWrapper::wrap(result);
+}
+
 void
 legion_future_map_destroy(legion_future_map_t fm_)
 {

--- a/runtime/legion/legion_c.h
+++ b/runtime/legion/legion_c.h
@@ -1976,6 +1976,14 @@ extern "C" {
   // -----------------------------------------------------------------------
 
   /**
+   * @return Caller takes ownership of return value.
+   *
+   * @see Legion::FutureMap::FutureMap()
+   */
+  legion_future_map_t
+  legion_future_map_copy(legion_future_map_t handle);
+
+  /**
    * @param handle Caller must have ownership of parameter `handle`.
    *
    * @see Legion::FutureMap::~FutureMap()

--- a/runtime/legion/legion_config.h
+++ b/runtime/legion/legion_config.h
@@ -105,7 +105,7 @@
 // Default amount of hysteresis on the task window in the
 // form of a percentage (must be between 0 and 100)
 #ifndef DEFAULT_TASK_WINDOW_HYSTERESIS
-#define DEFAULT_TASK_WINDOW_HYSTERESIS  75
+#define DEFAULT_TASK_WINDOW_HYSTERESIS  25
 #endif
 // Default number of tasks to have in flight before applying 
 // back pressure to the mapping process for a context

--- a/runtime/legion/legion_context.cc
+++ b/runtime/legion/legion_context.cc
@@ -1771,6 +1771,8 @@ namespace Legion {
     void TaskContext::end_misspeculation(const void *result, size_t result_size)
     //--------------------------------------------------------------------------
     {
+      // Mark that we are done executing this operation
+      owner_task->complete_execution();
       // Grab some information before doing the next step in case it
       // results in the deletion of 'this'
 #ifdef DEBUG_LEGION

--- a/runtime/legion/legion_context.cc
+++ b/runtime/legion/legion_context.cc
@@ -4466,7 +4466,7 @@ namespace Legion {
       RtEvent wait_event;
       // Take the context lock in exclusive mode
       {
-        AutoLock win_lock(window_lock);
+        AutoLock child_lock(child_op_lock);
         // We already hold our lock from the callsite above
         // Outstanding children count has already been incremented for the
         // operation being launched so decrement it in case we wait and then

--- a/runtime/legion/legion_context.cc
+++ b/runtime/legion/legion_context.cc
@@ -6534,6 +6534,8 @@ namespace Legion {
     {
       const PrepipelineArgs *pargs = (const PrepipelineArgs*)args;
       pargs->context->process_prepipeline_stage();
+      if (pargs->context->remove_reference())
+        delete pargs->context;
     }
 
     //--------------------------------------------------------------------------

--- a/runtime/legion/legion_context.cc
+++ b/runtime/legion/legion_context.cc
@@ -6279,6 +6279,13 @@ namespace Legion {
           runtime->add_to_dependence_queue(this, executing_processor, close_op);
         }
       }
+      // Mark that we are done executing this operation
+      // We're not actually done until we have registered our pending
+      // decrement of our parent task and recorded any profiling
+      if (!pending_done.has_triggered())
+        owner_task->complete_execution(pending_done);
+      else
+        owner_task->complete_execution();
       // Grab some information before doing the next step in case it
       // results in the deletion of 'this'
 #ifdef DEBUG_LEGION
@@ -6381,14 +6388,7 @@ namespace Legion {
           single_task->handle_post_mapped(Runtime::merge_events(preconditions));
         else
           single_task->handle_post_mapped();
-      }
-      // Mark that we are done executing this operation
-      // We're not actually done until we have registered our pending
-      // decrement of our parent task and recorded any profiling
-      if (!pending_done.has_triggered())
-        owner_task->complete_execution(pending_done);
-      else
-        owner_task->complete_execution();
+      } 
       if (need_complete)
         owner_task->trigger_children_complete();
       if (need_commit)
@@ -8678,6 +8678,20 @@ namespace Legion {
         const long long diff = current - previous_profiling_time;
         overhead_tracker->application_time += diff;
       }
+      // Unmap any physical regions that we mapped
+      for (std::vector<PhysicalRegion>::const_iterator it = 
+            physical_regions.begin(); it != physical_regions.end(); it++)
+      {
+        if (it->is_mapped())
+          it->impl->unmap_region();
+      }
+      // Mark that we are done executing this operation
+      // We're not actually done until we have registered our pending
+      // decrement of our parent task and recorded any profiling
+      if (!pending_done.has_triggered())
+        owner_task->complete_execution(pending_done);
+      else
+        owner_task->complete_execution();
       // Grab some information before doing the next step in case it
       // results in the deletion of 'this'
 #ifdef DEBUG_LEGION
@@ -8746,21 +8760,7 @@ namespace Legion {
           need_commit = true;
           children_commit_invoked = true;
         }
-      }
-      // Finally unmap any physical regions that we mapped
-      for (std::vector<PhysicalRegion>::const_iterator it = 
-            physical_regions.begin(); it != physical_regions.end(); it++)
-      {
-        if (it->is_mapped())
-          it->impl->unmap_region();
-      }
-      // Mark that we are done executing this operation
-      // We're not actually done until we have registered our pending
-      // decrement of our parent task and recorded any profiling
-      if (!pending_done.has_triggered())
-        owner_task->complete_execution(pending_done);
-      else
-        owner_task->complete_execution();
+      } 
       if (need_complete)
         owner_task->trigger_children_complete();
       if (need_commit)

--- a/runtime/legion/legion_context.h
+++ b/runtime/legion/legion_context.h
@@ -567,13 +567,15 @@ namespace Legion {
 
     class InnerContext : public TaskContext {
     public:
+      // Prepipeline stages need to hold a reference since the
+      // logical analysis could clean the context up before it runs
       struct PrepipelineArgs : public LgTaskArgs<PrepipelineArgs> {
       public:
         static const LgTaskID TASK_ID = LG_PRE_PIPELINE_ID;
       public:
         PrepipelineArgs(Operation *op, InnerContext *ctx)
           : LgTaskArgs<PrepipelineArgs>(op->get_unique_op_id()),
-            context(ctx) { }
+            context(ctx) { ctx->add_reference(); }
       public:
         InnerContext *const context;
       };

--- a/runtime/legion/legion_context.h
+++ b/runtime/legion/legion_context.h
@@ -1055,9 +1055,6 @@ namespace Legion {
       // Traces for this task's execution
       LegionMap<TraceID,DynamicTrace*,TASK_TRACES_ALLOC>::tracked traces;
       LegionTrace *current_trace;
-      // Event for waiting when the number of mapping+executing
-      // child operations has grown too large.
-      mutable LocalLock window_lock;
       bool valid_wait_event;
       RtUserEvent window_wait;
       std::deque<ApEvent> frame_events;

--- a/runtime/legion/legion_ops.cc
+++ b/runtime/legion/legion_ops.cc
@@ -2549,8 +2549,7 @@ namespace Legion {
         // Issue a deferred trigger on our completion event
         // and mark that we are no longer responsible for 
         // triggering our completion event
-        Runtime::trigger_event(completion_event, map_complete_event);
-        need_completion_trigger = false;
+        request_early_complete(map_complete_event);
         DeferredExecuteArgs deferred_execute_args(this);
         runtime->issue_runtime_meta_task(deferred_execute_args,
                                          LG_THROUGHPUT_DEFERRED_PRIORITY,
@@ -3896,8 +3895,7 @@ namespace Legion {
       if (!acquired_instances.empty())
         release_acquired_instances(acquired_instances);
       // Handle the case for marking when the copy completes
-      Runtime::trigger_event(completion_event, copy_complete_event);
-      need_completion_trigger = false;
+      request_early_complete(copy_complete_event);
       complete_execution(Runtime::protect_event(copy_complete_event));
     }
 
@@ -4952,8 +4950,7 @@ namespace Legion {
       // and we are executed when all our points are executed
       complete_mapping(Runtime::merge_events(mapped_preconditions));
       ApEvent done = Runtime::merge_events(executed_preconditions);
-      Runtime::trigger_event(completion_event, done); 
-      need_completion_trigger = false;
+      request_early_complete(done);
       complete_execution(Runtime::protect_event(done));
     }
 
@@ -5506,8 +5503,7 @@ namespace Legion {
         case EXECUTION_FENCE:
           {
             // We can always trigger the completion event when these are done
-            need_completion_trigger = false;
-            Runtime::trigger_event(completion_event, execution_precondition);
+            request_early_complete(execution_precondition);
             if (!execution_precondition.has_triggered())
             {
               RtEvent wait_on = Runtime::protect_event(execution_precondition);
@@ -5643,8 +5639,7 @@ namespace Legion {
 #endif
       ApEvent done = Runtime::merge_events(trigger_events);
       // We can always trigger the completion event when these are done
-      Runtime::trigger_event(completion_event, done);
-      need_completion_trigger = false;
+      request_early_complete(done);
       if (!done.has_triggered())
       {
         RtEvent wait_on = Runtime::protect_event(done);
@@ -7535,8 +7530,7 @@ namespace Legion {
         complete_mapping();
       if (!acquired_instances.empty())
         release_acquired_instances(acquired_instances);
-      Runtime::trigger_event(completion_event, close_event);
-      need_completion_trigger = false;
+      request_early_complete(close_event);
       complete_execution(Runtime::protect_event(close_event));
     }
 
@@ -8128,8 +8122,7 @@ namespace Legion {
         complete_mapping();
       if (!acquired_instances.empty())
         release_acquired_instances(acquired_instances);
-      Runtime::trigger_event(completion_event, acquire_complete);
-      need_completion_trigger = false;
+      request_early_complete(acquire_complete);
       complete_execution(Runtime::protect_event(acquire_complete));
     }
 
@@ -8744,8 +8737,7 @@ namespace Legion {
         complete_mapping();
       if (!acquired_instances.empty())
         release_acquired_instances(acquired_instances);
-      Runtime::trigger_event(completion_event, release_complete);
-      need_completion_trigger = false;
+      request_early_complete(release_complete);
       complete_execution(Runtime::protect_event(release_complete));
     }
 
@@ -11178,8 +11170,7 @@ namespace Legion {
       // Perform the partitioning operation
       ApEvent ready_event = thunk->perform(this, runtime->forest);
       complete_mapping();
-      Runtime::trigger_event(completion_event, ready_event);
-      need_completion_trigger = false;
+      request_early_complete(ready_event);
       complete_execution(Runtime::protect_event(ready_event));
     }
 
@@ -11787,8 +11778,7 @@ namespace Legion {
         LegionSpy::log_operation_events(unique_op_id, done_event,
                                         completion_event);
 #endif
-      Runtime::trigger_event(completion_event, done_event);
-      need_completion_trigger = false;
+      request_early_complete(done_event);
       complete_execution(Runtime::protect_event(done_event));
     }
 
@@ -11826,8 +11816,7 @@ namespace Legion {
         {
           ApEvent done_event = thunk->perform(this, runtime->forest,
               Runtime::merge_events(index_preconditions), instances);
-          Runtime::trigger_event(completion_event, done_event);
-          need_completion_trigger = false;
+          request_early_complete(done_event);
 #ifdef LEGION_SPY
           Runtime::trigger_event(intermediate_index_event, done_event);
 #endif
@@ -13418,8 +13407,7 @@ namespace Legion {
       // and we are executed when all our points are executed
       complete_mapping(Runtime::merge_events(mapped_preconditions));
       ApEvent done = Runtime::merge_events(executed_preconditions);
-      Runtime::trigger_event(completion_event, done);
-      need_completion_trigger = false;
+      request_early_complete(done);
       complete_execution(Runtime::protect_event(done));
     }
 
@@ -13989,8 +13977,7 @@ namespace Legion {
       else
         complete_mapping();
       ApEvent attach_event = result.get_ready_event();
-      Runtime::trigger_event(completion_event, attach_event);
-      need_completion_trigger = false;
+      request_early_complete(attach_event);
       complete_execution(Runtime::protect_event(attach_event));
     }
 
@@ -14477,8 +14464,7 @@ namespace Legion {
       else
         complete_mapping();
 
-      Runtime::trigger_event(completion_event, detach_event);
-      need_completion_trigger = false;
+      request_early_complete(detach_event);
       complete_execution(Runtime::protect_event(detach_event));
     }
 

--- a/runtime/legion/legion_ops.h
+++ b/runtime/legion/legion_ops.h
@@ -239,7 +239,7 @@ namespace Legion {
       virtual void activate(void) = 0;
       virtual void deactivate(void) = 0; 
       virtual const char* get_logging_name(void) const = 0;
-      virtual OpKind get_operation_kind(void) const  = 0;
+      virtual OpKind get_operation_kind(void) const = 0;
       virtual size_t get_region_count(void) const;
       virtual Mappable* get_mappable(void);
     protected:
@@ -574,8 +574,6 @@ namespace Legion {
       RtUserEvent mapped_event;
       // The resolved event for this operation
       RtUserEvent resolved_event;
-      // The event for when any children this operation has are mapped
-      //Event children_mapped;
       // The completion event for this operation
       ApUserEvent completion_event;
       // The commit event for this operation

--- a/runtime/legion/legion_ops.h
+++ b/runtime/legion/legion_ops.h
@@ -424,6 +424,33 @@ namespace Legion {
       // rest of the operations in the graph
       void quash_operation(GenerationID gen, bool restart);
     public:
+      // For operations that wish to complete early they can do so
+      // using this method which will allow them to immediately 
+      // chain an event to directly trigger the completion event
+      // Note that we don't support early completion if we're doing
+      // inorder program execution
+      inline bool request_early_complete(ApEvent chain_event) 
+        {
+          if (!runtime->program_order_execution)
+          {
+            need_completion_trigger = false;
+            Runtime::trigger_event(completion_event, chain_event);
+            return true;
+          }
+          else
+            return false;
+        }
+      inline bool request_early_complete_no_trigger(ApUserEvent &to_trigger)
+        {
+          if (!runtime->program_order_execution)
+          {
+            need_completion_trigger = false;
+            to_trigger = completion_event;
+            return true;
+          }
+          else
+            return false;
+        }
       // For operations that need to trigger commit early,
       // then they should use this call to avoid races
       // which could result in trigger commit being

--- a/runtime/legion/legion_tasks.cc
+++ b/runtime/legion/legion_tasks.cc
@@ -5135,12 +5135,12 @@ namespace Legion {
         return false;
       if (!restrict_postconditions.empty())
         return false;
+      if (runtime->program_order_execution)
+        return false;
       // Otherwise we're going to do it mark that we
       // don't need to trigger the underlying completion event.
       // Note we need to do this now to avoid any race condition.
-      need_completion_trigger = false;
-      chain_event = completion_event;
-      return true;
+      return request_early_complete_no_trigger(chain_event);
     }
 
     //--------------------------------------------------------------------------
@@ -7118,8 +7118,7 @@ namespace Legion {
       if (!completion_preconditions.empty())
       {
         ApEvent done = Runtime::merge_events(completion_preconditions);
-        need_completion_trigger = false;
-        Runtime::trigger_event(completion_event, done);
+        request_early_complete(done);
       }
       complete_operation();
 #ifdef LEGION_SPY

--- a/runtime/legion/runtime.cc
+++ b/runtime/legion/runtime.cc
@@ -12434,6 +12434,7 @@ namespace Legion {
             request_event = Runtime::create_rt_user_event();
             record.ready = request_event;
             record.result_set = false;
+            wait_on = request_event;
           }
         }
       }
@@ -12649,6 +12650,7 @@ namespace Legion {
             request_event = Runtime::create_rt_user_event();
             record.ready = request_event;
             record.result_set = false;
+            wait_on = request_event;
           }
         }
       }
@@ -13064,6 +13066,7 @@ namespace Legion {
             request_event = Runtime::create_rt_user_event();
             record.ready = request_event;
             record.result_set = false;
+            wait_on = request_event;
           }
         }
       }

--- a/runtime/realm/deppart/setops.cc
+++ b/runtime/realm/deppart/setops.cc
@@ -1319,10 +1319,11 @@ namespace Realm {
 	  break;
 	}
 
-	// consume lhs rectangles until we get one that overlaps
-	while(it_lhs.rect.hi.x < it_rhs.rect.lo.x) {
+	// an lhs rectangle that is entirely below the first rhs is taken as is
+	if(it_lhs.rect.hi.x < it_rhs.rect.lo.x) {
 	  bitmask.add_rect(it_lhs.rect);
-	  if(!it_lhs.step()) break;
+	  it_lhs.step();
+	  continue;
 	}
 
 	// last case - partial overlap - subtract out rhs rect(s)

--- a/runtime/realm/inst_impl.cc
+++ b/runtime/realm/inst_impl.cc
@@ -426,6 +426,9 @@ namespace Realm {
       metadata.inst_offset = (size_t)-1;
       metadata.ready_event = Event::NO_EVENT;
       metadata.layout = 0;
+      
+      // Initialize this in case the user asks for profiling information
+      timeline.instance = _me;
     }
 
     RegionInstanceImpl::~RegionInstanceImpl(void)

--- a/runtime/realm/operation.cc
+++ b/runtime/realm/operation.cc
@@ -607,7 +607,7 @@ namespace Realm {
       }
     }
 
-    os << "}";
+    os << "}\n";
 #endif
   }
 

--- a/runtime/realm/python/python_internal.h
+++ b/runtime/realm/python/python_internal.h
@@ -191,11 +191,14 @@ namespace Realm {
     //   should release the GIL)
     virtual void thread_blocking(Thread *thread);
 
+    virtual void thread_ready(Thread *thread);
+
   protected:
     virtual Thread *worker_create(bool make_active);
     virtual void worker_terminate(Thread *switch_to);
 
     LocalPythonProcessor *pyproc;
+    bool interpreter_ready;
     std::list<LocalPythonProcessor::TaskRegistration *> taskreg_queue;
     std::map<Thread *, PyThreadState *> pythreads;
   };

--- a/runtime/realm/python/python_module.cc
+++ b/runtime/realm/python/python_module.cc
@@ -275,6 +275,7 @@ namespace Realm {
 						       CoreReservation& _core_rsrv)
     : KernelThreadTaskScheduler(_pyproc->me, _core_rsrv)
     , pyproc(_pyproc)
+    , interpreter_ready(false)
   {}
 
   void PythonThreadTaskScheduler::enqueue_taskreg(LocalPythonProcessor::TaskRegistration *treg)
@@ -288,9 +289,10 @@ namespace Realm {
   void PythonThreadTaskScheduler::python_scheduler_loop(void)
   {
     // global startup of python interpreter if needed
-    if(pyproc->interpreter == 0) {
+    if(!interpreter_ready) {
       log_py.info() << "creating interpreter";
       pyproc->create_interpreter();
+      interpreter_ready = true;
     }
 
     // always create and remember our own python thread - does NOT require GIL
@@ -487,6 +489,31 @@ namespace Realm {
   //   should release the GIL)
   void PythonThreadTaskScheduler::thread_blocking(Thread *thread)
   {
+    // if this gets called before we're done initializing the interpreter,
+    //  we need a simple blocking wait
+    if(!interpreter_ready) {
+      AutoHSLLock al(lock);
+
+      log_py.debug() << "waiting during initialization";
+      bool really_blocked = try_update_thread_state(thread,
+						    Thread::STATE_BLOCKING,
+						    Thread::STATE_BLOCKED);
+      if(!really_blocked) return;
+
+      while(true) {
+	long long old_work_counter = work_counter.read_counter();
+
+	if(!resumable_workers.empty()) {
+	  Thread *t = resumable_workers.get(0);
+	  assert(t == thread);
+	  log_py.debug() << "awake again";
+	  return;
+	}
+
+	wait_for_work(old_work_counter);
+      }
+    }
+
     // if we got here through a cffi call, the GIL has already been released,
     //  so try to handle that case here - a call PyEval_SaveThread
     //  if the GIL is not held will assert-fail, and while a call to
@@ -512,6 +539,17 @@ namespace Realm {
       (pyproc->interpreter->api->PyEval_RestoreThread)(saved);
     } else
       log_py.info() << "python worker awake - not acquiring GIL";
+  }
+
+  void PythonThreadTaskScheduler::thread_ready(Thread *thread)
+  {
+    // handle the wakening of the initialization thread specially
+    if(!interpreter_ready) {
+      AutoHSLLock al(lock);
+      resumable_workers.put(thread, 0);
+    } else {
+      KernelThreadTaskScheduler::thread_ready(thread);
+    }
   }
 
   void PythonThreadTaskScheduler::worker_terminate(Thread *switch_to)

--- a/runtime/realm/transfer/lowlevel_dma.cc
+++ b/runtime/realm/transfer/lowlevel_dma.cc
@@ -1565,7 +1565,7 @@ namespace Realm {
     static TransferIterator *deserialize_new(S& deserializer);
       
     virtual void reset(void);
-    virtual bool done(void) const;
+    virtual bool done(void);
 
     virtual size_t step(size_t max_bytes, AddressInfo& info,
 			unsigned flags,
@@ -1614,7 +1614,7 @@ namespace Realm {
     offset = 0;
   }
 
-  bool WrappingFIFOIterator::done(void) const
+  bool WrappingFIFOIterator::done(void)
   {
     // we never know when we're done
     return false;

--- a/runtime/realm/transfer/transfer.h
+++ b/runtime/realm/transfer/transfer.h
@@ -43,7 +43,7 @@ namespace Realm {
     virtual Event request_metadata(void);
 
     virtual void reset(void) = 0;
-    virtual bool done(void) const = 0;
+    virtual bool done(void) = 0;
 
     // flag bits to control iterators
     enum {

--- a/test.py
+++ b/test.py
@@ -82,6 +82,7 @@ legion_python_cxx_tests = [
     # Bindings
     ['bindings/python/legion_python', ['hello', '-ll:py', '1', '-ll:cpu', '0']],
     ['bindings/python/legion_python', ['region', '-ll:py', '1', '-ll:cpu', '0']],
+    ['bindings/python/legion_python', ['index_launch', '-ll:py', '1', '-ll:cpu', '0']],
 
     # Examples
     ['examples/python_interop/python_interop', ['-ll:py', '1']],


### PR DESCRIPTION
This is currently the 2nd slowest pass when compiling Soleil on my local machine (behind actual LLVM compilation):

compile 72.692785
inline_tasks 0.624195
optimize_divergence 1.045345
normalize after type check 1.723449
optimize_mapping 6.727169
skip_empty_tasks 2.743174
vectorize_loops 0.154155
parallelize_tasks 49.717688
codegen 13.026204
optimize_index_launches 6.307519
normalize after specialize 1.132306
optimize_traces 4.432626
type check 7.364484
specialize 1.237845
optimize_futures 1.045139
optimize_config_options 63.565161
check annotations 15.551507

With this patch, the running time of this pass drops almost 10x (and even parallelize_tasks seems to speed up by ~40%, although that might be a fluke):

compile 71.073906
inline_tasks 0.614681
optimize_divergence 1.047141
normalize after type check 1.701131
optimize_mapping 6.579061
skip_empty_tasks 2.818497
vectorize_loops 0.136539
parallelize_tasks 28.291654
codegen 12.216086
optimize_index_launches 6.1847
normalize after specialize 1.092664
optimize_traces 4.326427
type check 7.297603
specialize 1.1884
optimize_futures 1.08264
optimize_config_options 6.633898
check annotations 14.641641