### PR TITLE
gasnet_coll include

### DIFF
--- a/runtime/realm/runtime_impl.cc
+++ b/runtime/realm/runtime_impl.cc
@@ -39,6 +39,7 @@
 #define GASNET_PAR
 #endif
 #include <gasnet.h>
+#include <gasnet_coll.h>
 // eliminate GASNet warnings for unused static functions
 static const void *ignore_gasnet_warning1 __attribute__((unused)) = (void *)_gasneti_threadkey_init;
 #ifdef _INCLUDED_GASNET_TOOLS_H


### PR DESCRIPTION
## Summary

This PR contains a single commit to fix a problem observed in testing Legion's 'stable' branch with GASNet's current 'develop' branch.  I have created the PR against 'master', assuming that is where new commits should start.  However, I'd hope to see this fix applied to 'stable' as well.

## Commit message:

*   realm: add explicit include of gasnet_coll.h  

     It was always the intention of the GASNet developers that clients
     using the collective extensions include gasnet_coll.h explicitly.
     However, due to an implementation quirk that was not actually
     necessary.  That implementation quirk has been removed in the current
     'develop' branch of GASNet, which breaks builds of the Realm runtime.
     So, this commit adds the missing include.