### PR TITLE
Remove ambiguity in calls to Point<N,T>(x)

### DIFF
--- a/runtime/realm/indexspace.inl
+++ b/runtime/realm/indexspace.inl
@@ -97,13 +97,13 @@ namespace Realm {
   template <int N, typename T>
   /*static*/ inline Point<N,T> Point<N,T>::ZEROES(void)
   {
-    return Point<N,T>(0);
+    return Point<N,T>(static_cast<T>(0));
   }
 
   template <int N, typename T>
   /*static*/ inline Point<N,T> Point<N,T>::ONES(void)
   {
-    return Point<N,T>(1);
+    return Point<N,T>(static_cast<T>(1));
   }
 
   // specializations for N <= 4
@@ -141,9 +141,9 @@ namespace Realm {
     operator T(void) const { return x; }
 
     __CUDA_HD__
-    static inline Point<1,T> ZEROES(void) { return Point<1,T>(0); }
+    static inline Point<1,T> ZEROES(void) { return Point<1,T>(static_cast<T>(0)); }
     __CUDA_HD__
-    static inline Point<1,T> ONES(void) { return Point<1,T>(1); }
+    static inline Point<1,T> ONES(void) { return Point<1,T>(static_cast<T>(1)); }
   };
 
   template <typename T>
@@ -181,9 +181,9 @@ namespace Realm {
     }
 
     __CUDA_HD__
-    static inline Point<2,T> ZEROES(void) { return Point<2,T>(0); }
+    static inline Point<2,T> ZEROES(void) { return Point<2,T>(static_cast<T>(0)); }
     __CUDA_HD__
-    static inline Point<2,T> ONES(void) { return Point<2,T>(1); }
+    static inline Point<2,T> ONES(void) { return Point<2,T>(static_cast<T>(1)); }
   };
 
   template <typename T>
@@ -222,9 +222,9 @@ namespace Realm {
     }
 
     __CUDA_HD__
-    static inline Point<3,T> ZEROES(void) { return Point<3,T>(0); }
+    static inline Point<3,T> ZEROES(void) { return Point<3,T>(static_cast<T>(0)); }
     __CUDA_HD__
-    static inline Point<3,T> ONES(void) { return Point<3,T>(1); }
+    static inline Point<3,T> ONES(void) { return Point<3,T>(static_cast<T>(1)); }
   };
 
   template <typename T>
@@ -264,9 +264,9 @@ namespace Realm {
     }
 
     __CUDA_HD__
-    static inline Point<4,T> ZEROES(void) { return Point<4,T>(0); }
+    static inline Point<4,T> ZEROES(void) { return Point<4,T>(static_cast<T>(0)); }
     __CUDA_HD__
-    static inline Point<4,T> ONES(void) { return Point<4,T>(1); }
+    static inline Point<4,T> ONES(void) { return Point<4,T>(static_cast<T>(1)); }
   };
 
   template <int N, typename T>


### PR DESCRIPTION
In `Point<N,T>::ZEROES()` and `Point<N,T>::ONES()`, calls to `Point<N,T>(0 /* 1 */)` are ambiguous when compiled with gcc-7.4 --std=c++17. Casting 0 and 1 to the type T fixes the issue.

Example of compile-time failure:
> .../include/realm/indexspace.inl: In instantiation of 'static Realm::Point<3, T> Realm::Point<3, T>::ZEROES() [with T = long long int]':
> .../Grids.h:139:29:   required from 'std::tuple<Legion::IndexPartition, Legion::IndexPartition> legms::block_and_halo_partitions(Legion::Context, Legion::Runtime*, const Legion::IndexSpaceT<D>&, Legion::Point<D>&, Legion::Point<D>&) [with int D = 3; Legion::Context = Legion::Internal::TaskContext*; Legion::Point<D> = Realm::Point<3, long long int>]'
> .../Grids_c.cc:68:45:   required from here
.../include/realm/indexspace.inl:225:52: error: call of overloaded 'Point(int)' is ambiguous
     static inline Point<3,T> ZEROES(void) { return Point<3,T>(0); }
                                                    ^~~~~~~~~~~~~
> .../include/realm/indexspace.inl:197:14: note: candidate: Realm::Point<3, T>::Point(const T*) [with T = long long int]
     explicit Point(const T vals[3]) : x(vals[0]), y(vals[1]), z(vals[2]) {}
              ^~~~~
> .../include/realm/indexspace.inl:195:5: note: candidate: Realm::Point<3, T>::Point(T) [with T = long long int]
     Point(T val) : x(val), y(val), z(val) { }
     ^~~~~
> .../include/realm/indexspace.inl:190:10: note: candidate: constexpr Realm::Point<3, long long int>::Point(const Realm::Point<3, long long int>&)
   struct Point<3,T> {
          ^~~~~~~~~~
> .../include/realm/indexspace.inl:190:10: note: candidate: constexpr Realm::Point<3, long long int>::Point(Realm::Point<3, long long int>&&)
