### PR TITLE
hwloc-2.0: use hwloc_linux_read_path_as_cpumask()

### DIFF
--- a/runtime/realm/threads.cc
+++ b/runtime/realm/threads.cc
@@ -1470,15 +1470,12 @@ namespace Realm {
 				std::set<int>& sibling_ids) {
     char str[1024];
     sprintf(str, "/sys/devices/system/cpu/cpu%d/topology/thread_siblings", cpu_id);
-    FILE *f = fopen(str, "r");
-    if(!f) {
+    hwloc_bitmap_t set = hwloc_bitmap_alloc();
+
+    if (hwloc_linux_read_path_as_cpumask(str, set) < 0) {
       log_thread.warning() << "can't read '" << str << "' - skipping";
       return false;
     }
-    hwloc_bitmap_t set = hwloc_bitmap_alloc();
-    hwloc_linux_parse_cpumap_file(f, set);
-
-    fclose(f);
 
     // loop over all siblings (except ourselves)
     for(int siblingid = hwloc_bitmap_first(set);


### PR DESCRIPTION
See https://github.com/open-mpi/hwloc/commit/e7f5962f014bbf9dcd284498b8662ec7645c2d4e.

The easy part of #575. 