### PR TITLE
Allow assignment operations on regions in Regent

### DIFF
--- a/language/src/regent/copy_propagate.t
+++ b/language/src/regent/copy_propagate.t
@@ -344,6 +344,8 @@ function copy_propagate.stat_if(cx, stat)
 end
 
 function copy_propagate.stat_while(cx, stat)
+  -- FIXME: This looks like it won't realize that if the variable is changed
+  -- later in the loop then on the next iteration it is not a copy.
   return stat {
     cond = copy_propagate.expr(cx, stat.cond),
     block = copy_propagate.block(cx, stat.block),

--- a/language/src/regent/copy_propagate.t
+++ b/language/src/regent/copy_propagate.t
@@ -344,8 +344,6 @@ function copy_propagate.stat_if(cx, stat)
 end
 
 function copy_propagate.stat_while(cx, stat)
-  -- FIXME: This looks like it won't realize that if the variable is changed
-  -- later in the loop then on the next iteration it is not a copy.
   return stat {
     cond = copy_propagate.expr(cx, stat.cond),
     block = copy_propagate.block(cx, stat.block),

--- a/language/src/regent/dataflow.t
+++ b/language/src/regent/dataflow.t
@@ -1,0 +1,298 @@
+-- Copyright 2019 Stanford University, NVIDIA Corporation
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- Data-flow analysis framework
+
+local ast = require("regent/ast")
+local std = require("regent/std")
+
+local dataflow = {}
+
+local forward_metatable = {}
+local forward = setmetatable({}, forward_metatable)
+forward.__index = forward
+dataflow.forward = forward
+
+-- TODO: Maybe make meet be in place
+
+-- Forward data-flow analysis. The following methods are needed for the
+-- semilattice:
+-- +, meet operation
+-- ==, check for equality of states (for determining convergence)
+-- :copy, duplicate state
+--
+-- Additionally, it needs the following four methods to implement the transfer
+-- function.
+--
+-- :enter_block
+-- :exit_block
+-- :statement (does not need to handle control flow)
+--
+-- After constructing an instance, which should only be used inside a single
+-- function, use :block to run the analysis on a block of code.
+
+function forward_metatable:__call(exit_state)
+  local out = {
+    block_entries = {},
+    exit_stack = { exit_state, len = 1 },
+  }
+
+  return setmetatable(out, forward)
+end
+
+function forward:exit_state()
+  return self.exit_stack[1]
+end
+
+local function push(stack, state)
+  stack.len = stack.len + 1
+  stack[stack.len] = state
+end
+
+local function pop(stack)
+  local top = stack[stack.len]
+  stack[stack.len] = nil
+  stack.len = stack.len - 1
+  return top
+end
+
+function forward:block(block, entry, dont_exit)
+  if not entry then
+    return nil
+  end
+
+  if self.block_entries[block] == entry then
+    -- No need to redo this execution path.
+    return nil
+  end
+  self.block_entries[block] = entry
+
+  entry:enter_block(block)
+  for _, stat in ipairs(block.stats) do
+    entry = self:stat(stat, entry)
+    if not entry then
+      return nil
+    end
+  end
+  if not dont_exit then
+    entry:exit_block(block)
+  end
+
+  return entry
+end
+
+function forward:stat_if(node, entry)
+  local cond = self:unused_expr(node.cond, entry)
+  local exit = self:block(node.then_block, dataflow.copy(cond))
+
+  for _, else_if in ipairs(node.elseif_blocks) do
+    cond = self:unused_expr(else_if.cond, cond)
+    local block = self:block(else_if.block, dataflow.copy(cond))
+    exit = dataflow.meet(exit, block)
+  end
+
+  local else_block = self:block(node.else_block, cond)
+  exit = dataflow.meet(exit, else_block)
+  return exit
+end
+
+function forward:stat_while(node, entry)
+  local exit
+  repeat
+    local cond = self:unused_expr(node.cond, dataflow.copy(entry))
+    exit = dataflow.meet_copy(exit, cond)
+    push(self.exit_stack, exit)
+    local block = self:block(node.block, cond)
+    exit = pop(self.exit_stack)
+
+    local updated
+    entry, updated = dataflow.meet_updated(entry, block)
+  until not updated
+
+  return exit
+end
+
+function forward:stat_repeat(node, entry)
+  local exit
+  repeat
+    push(self.exit_stack, exit)
+    local block = self:block(node.block, dataflow.copy(entry), true)
+    local cond = self:unused_expr(node.until_cond, block)
+    if cond then
+      cond:exit_block(node.block)
+    end
+    exit = dataflow.meet(pop(self.exit_stack), cond)
+
+    local updated
+    entry, updated = dataflow.meet_updated(entry, cond)
+  until not updated
+
+  return exit
+end
+
+function forward:stat_for_num(node, entry)
+  for _, value in ipairs(node.values) do
+    entry = self:unused_expr(value, entry)
+  end
+
+  local exit
+  repeat
+    exit = dataflow.meet(exit, entry)
+    push(self.exit_stack, exit)
+    local block = self:block(node.block, dataflow.copy(entry))
+    exit = pop(self.exit_stack)
+
+    local updated
+    entry, updated = dataflow.meet_updated(entry, block)
+  until not updated
+
+  return exit
+end
+
+function forward:stat_for_list(node, entry)
+  entry = self:unused_expr(node.value, entry)
+
+  local exit
+  repeat
+    exit = dataflow.meet(exit, entry)
+    push(self.exit_stack, exit)
+    local block = self:block(node.block, dataflow.copy(entry))
+    exit = pop(self.exit_stack)
+
+    local updated
+    entry, updated = dataflow.meet_updated(entry, block)
+  until not updated
+
+  return exit
+end
+
+function forward:stat_block(node, entry)
+  return self:block(node.block, entry)
+end
+
+function forward:stat_break(node, entry)
+  entry:statement(node)
+  push(self.exit_stack, dataflow.meet_copy(pop(self.exit_stack), entry))
+
+  -- nil represents unreachable code.
+  return nil
+end
+
+function forward:stat_return(node, entry)
+  entry:statement(node)
+  self.exit_stack[1] = dataflow.meet_copy(self.exit_stack[1], entry)
+
+  return nil
+end
+
+function forward:stat_other(node, entry)
+  entry:statement(node)
+  return entry
+end
+
+local function unreachable()
+  assert(false, "unreachable")
+end
+
+local forward_stat_node = {
+  [ast.typed.stat.If]                = forward.stat_if,
+  [ast.typed.stat.While]             = forward.stat_while,
+  [ast.typed.stat.ForNum]            = forward.stat_for_num,
+  [ast.typed.stat.ForNumVectorized]  = forward.stat_for_num,
+  [ast.typed.stat.IndexLaunchNum]    = forward.stat_for_num,
+  [ast.typed.stat.ForList]           = forward.stat_for_list,
+  [ast.typed.stat.ForListVectorized] = forward.stat_for_list,
+  [ast.typed.stat.IndexLaunchList]   = forward.stat_for_list,
+  [ast.typed.stat.Repeat]            = forward.stat_repeat,
+  [ast.typed.stat.Block]             = forward.stat_block,
+  [ast.typed.stat.MustEpoch]         = forward.stat_block,
+  [ast.typed.stat.ParallelizeWith]   = forward.stat_block,
+  [ast.typed.stat.Break]             = forward.stat_break,
+  [ast.typed.stat.Return]            = forward.stat_return,
+
+  [ast.typed.stat.Var]               = forward.stat_other,
+  [ast.typed.stat.VarUnpack]         = forward.stat_other,
+  [ast.typed.stat.Expr]              = forward.stat_other,
+  [ast.typed.stat.Assignment]        = forward.stat_other,
+  [ast.typed.stat.Reduce]            = forward.stat_other,
+  [ast.typed.stat.RawDelete]         = forward.stat_other,
+  [ast.typed.stat.Fence]             = forward.stat_other,
+  [ast.typed.stat.ParallelPrefix]    = forward.stat_other,
+  [ast.typed.stat.BeginTrace]        = forward.stat_other,
+  [ast.typed.stat.EndTrace]          = forward.stat_other,
+  [ast.typed.stat.MapRegions]        = forward.stat_other,
+  [ast.typed.stat.UnmapRegions]      = forward.stat_other,
+
+  [ast.typed.stat.Elseif]   = unreachable,
+  [ast.typed.stat.Internal] = unreachable,
+}
+
+local forward_stat = ast.make_single_dispatch(forward_stat_node, {ast.typed.stat})
+function forward:stat(...)
+  return forward_stat(self)(...)
+end
+
+function forward:unused_expr(node, entry)
+  if not entry then
+    return nil
+  end
+
+  entry:statement(
+    ast.typed.stat.Expr {
+      expr = node,
+      span = node.span,
+      annotations = node.annotations,
+    })
+  return entry
+end
+
+function dataflow.meet(x, y)
+  if not y then
+    return x
+  elseif not x then
+    return y
+  else
+    return x + y
+  end
+end
+
+function dataflow.meet_copy(x, y)
+  if not y then
+    return x
+  elseif not x then
+    return y:copy()
+  else
+    return x + y
+  end
+end
+
+function dataflow.meet_updated(prev, x)
+  if not prev then
+    return x, prev ~= x
+  elseif not x then
+    return prev, false
+  else
+    local new = prev + x
+    return new, prev ~= new
+  end
+end
+
+function dataflow.copy(x)
+  if not x then
+    return nil
+  end
+  return x:copy()
+end
+
+return dataflow

--- a/language/src/regent/desugar.t
+++ b/language/src/regent/desugar.t
@@ -58,7 +58,7 @@ local function desugar_image_by_task(cx, node)
     std.newsymbol(partition_type:colors().index_type(colors_symbol))
   local colors_expr = ast_util.mk_expr_colors_access(partition)
   local subregion_type = partition_type:subregion_dynamic()
-  std.add_constraint(cx, subregion_type, partition_type, std.subregion, false)
+  cx.constraints:add_constraint(subregion_type, partition_type, std.subregion)
 
   local subregion_expr =
     ast_util.mk_expr_index_access(partition,
@@ -85,7 +85,6 @@ local function desugar_image_by_task(cx, node)
                          ast_util.mk_expr_partition(image_partition_type,
                                                     ast_util.mk_expr_id(colors_symbol),
                                                     coloring_expr)))
-  std.add_constraint(cx, image_partition_type, parent_type, std.subregion, false)
 
   stats:insert(
     ast_util.mk_stat_expr(
@@ -175,7 +174,7 @@ function desugar.block(cx, block)
 end
 
 function desugar.top_task(node)
-  local cx = { constraints = node.prototype:get_constraints() }
+  local cx = { constraints = node.prototype:get_region_context() }
   local body = node.body and desugar.block(cx, node.body) or false
 
   return node { body = body }

--- a/language/src/regent/optimize_mapping.t
+++ b/language/src/regent/optimize_mapping.t
@@ -34,10 +34,10 @@ function context:__newindex (field, value)
   error ("context has no field '" .. field .. "' (in assignment)", 2)
 end
 
-function context:new_task_scope(constraints, region_universe)
-  assert(constraints and region_universe)
+function context:new_task_scope(region_cx, region_universe)
+  assert(region_cx and region_universe)
   local cx = {
-    constraints = constraints,
+    region_cx = region_cx,
     region_universe = region_universe,
   }
   return setmetatable(cx, context)
@@ -71,7 +71,7 @@ local function uses(cx, region_type, polarity)
         other_region_type,
         std.disjointness)
       if std.type_maybe_eq(region_type:fspace(), other_region_type:fspace()) and
-        not std.check_constraint(cx, constraint)
+        not cx.region_cx:check_constraint(constraint)
       then
         usage[other_region_type] = polarity
       end
@@ -612,7 +612,7 @@ function optimize_mapping.top_task(cx, node)
   if not node.body then return node end
 
   local cx = cx:new_task_scope(
-    node.prototype:get_constraints(),
+    node.prototype:get_region_context(),
     node.prototype:get_region_universe())
   local initial_usage = task_initial_usage(cx, node.privileges)
   local annotated_body = optimize_mapping.block(cx, node.body)

--- a/language/src/regent/std_base.t
+++ b/language/src/regent/std_base.t
@@ -1230,15 +1230,15 @@ function base.task:get_param_constraints()
   return self.param_constraints
 end
 
-function base.task:set_constraints(t)
-  assert(not self.constraints)
-  assert(t)
-  self.constraints = t
+function base.task:set_region_context(cx)
+  assert(not self.region_cx)
+  assert(cx)
+  self.region_cx = cx
 end
 
-function base.task:get_constraints()
-  assert(self.constraints)
-  return self.constraints
+function base.task:get_region_context()
+  assert(self.region_cx)
+  return self.region_cx
 end
 
 function base.task:set_region_universe(t)
@@ -1432,7 +1432,7 @@ do
       flags = false,
       conditions = false,
       param_constraints = false,
-      constraints = false,
+      region_cx = false,
       region_universe = false,
 
       -- Variants and alternative versions:

--- a/language/src/regent/symbol_table.t
+++ b/language/src/regent/symbol_table.t
@@ -69,6 +69,11 @@ function symbol_table:insert(node, index, value)
   return value
 end
 
+function symbol_table:force_insert(index, value)
+  rawset(self.local_env, index, value)
+  return value
+end
+
 function symbol_table:env()
   return self.combined_env
 end

--- a/language/src/regent/type_check.t
+++ b/language/src/regent/type_check.t
@@ -2930,6 +2930,7 @@ function type_check.expr_with_scratch_fields(cx, node)
   end
 
   std.copy_privileges(cx, region_type, expr_type)
+  cx:intern_region(expr_type)
 
   return ast.typed.expr.WithScratchFields {
     region = region,

--- a/language/src/regent/type_check.t
+++ b/language/src/regent/type_check.t
@@ -3561,8 +3561,8 @@ end
 function type_check.declare_phi_vars(cx, node, changed_regions, stats, region_mapping)
   for region in pairs(changed_regions) do
     local old_type = region:gettype()
-    --local type = std.region(std.newsymbol(old_type:ispace(), old_type.ispace_symbol.hasname()), old_type:fspace())
-    local type = std.region(old_type.ispace_symbol, old_type:fspace())
+    local type = std.region(std.newsymbol(old_type:ispace(), old_type.ispace_symbol:hasname()), old_type:fspace())
+    --local type = std.region(old_type.ispace_symbol, old_type:fspace())
     local renamed_region = std.newsymbol(type, region:getname())
     cx.type_env:insert(node, renamed_region, std.rawref(&type))
     region_mapping[region] = renamed_region

--- a/language/tests/regent/compile_fail/region_assignment1.rg
+++ b/language/tests/regent/compile_fail/region_assignment1.rg
@@ -1,0 +1,42 @@
+-- Copyright 2019 Stanford University
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- fails-with:
+-- region_assignment1.rg:40: invalid call missing constraint $x <= $s
+
+import "regent"
+
+task assert_subregion(x : region(int), y : region(int))
+where
+  x <= y
+do
+end
+
+task main()
+  var s = region(ispace(ptr, 5), int)
+  var t = region(ispace(ptr, 5), int)
+
+  s[0] = 1
+  t[0] = 2
+
+  var x : region(int)
+  if true then
+    x = s
+  else
+    x = t
+  end
+
+  assert_subregion(x, s)
+end
+regentlib.start(main)

--- a/language/tests/regent/compile_fail/region_assignment2.rg
+++ b/language/tests/regent/compile_fail/region_assignment2.rg
@@ -1,0 +1,42 @@
+-- Copyright 2019 Stanford University
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- fails-with:
+-- region_assignment2.rg:40: invalid call missing constraint $x * $s
+
+import "regent"
+
+task assert_disjoint(x : region(int), y : region(int))
+where
+  x * y
+do
+end
+
+task main()
+  var s = region(ispace(ptr, 5), int)
+  var t = region(ispace(ptr, 5), int)
+
+  s[0] = 1
+  t[0] = 2
+
+  var x : region(int)
+  if true then
+    x = s
+  else
+    x = t
+  end
+
+  assert_disjoint(x, s)
+end
+regentlib.start(main)

--- a/language/tests/regent/compile_fail/type_mismatch_parallel_prefix13.rg
+++ b/language/tests/regent/compile_fail/type_mismatch_parallel_prefix13.rg
@@ -13,7 +13,7 @@
 -- limitations under the License.
 
 -- fails-with:
--- type_mismatch_parallel_prefix13.rg:24: invalid privilege in argument 1: writes($r)
+-- type_mismatch_parallel_prefix13.rg:24: invalid privileges in argument 1: writes($r)
 --     __parallel_prefix(r, s, +, 1)
 --                       ^
 

--- a/language/tests/regent/compile_fail/type_mismatch_parallel_prefix14.rg
+++ b/language/tests/regent/compile_fail/type_mismatch_parallel_prefix14.rg
@@ -13,7 +13,7 @@
 -- limitations under the License.
 
 -- fails-with:
--- type_mismatch_parallel_prefix14.rg:26: invalid privilege in argument 2: reads($s)
+-- type_mismatch_parallel_prefix14.rg:26: invalid privileges in argument 2: reads($s)
 --   __parallel_prefix(r, s, +, 1)
 --                        ^
 

--- a/language/tests/regent/run_pass/privilege_reduce5.rg
+++ b/language/tests/regent/run_pass/privilege_reduce5.rg
@@ -1,0 +1,40 @@
+-- Copyright 2019 Stanford University
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+import "regent"
+
+fspace s {
+  a : int,
+}
+
+task f(r : region(s))
+where
+  reduces +(r.a)
+do
+  r[0].a += 10
+end
+
+task g(r : region(s))
+where
+  reads(r),
+  writes(r.a)
+do
+  f(r)
+end
+
+task main()
+  var r = region(ispace(int1d, 1), a)
+  g(r)
+end
+regentlib.start(main)

--- a/language/tests/regent/run_pass/region_assignment1.rg
+++ b/language/tests/regent/run_pass/region_assignment1.rg
@@ -12,11 +12,6 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
--- fails-with:
--- type_mismatch_assignment2.rg:26: type mismatch in assignment: expected region(int32) but got region(int32)
---   s = t
---   ^
-
 import "regent"
 
 task f()

--- a/language/tests/regent/run_pass/region_assignment2.rg
+++ b/language/tests/regent/run_pass/region_assignment2.rg
@@ -14,27 +14,22 @@
 
 import "regent"
 
-task foo(x : region(int), y : region(int))
-where
-  x <= y,
-  y <= x,
-  reads writes(x)
-do
-  y[0] = x[0]
-  x[0] = y[0]
-end
-
 task main()
   var s = region(ispace(ptr, 5), int)
   var t = region(ispace(ptr, 5), int)
+
   s[0] = 1
   t[0] = 2
 
-  s = t
-  foo(s, t)
+  var x : region(int)
+  if true then
+    x = s
+  else
+    x = t
+  end
 
-  regentlib.assert(s[0] == 2, "test failed")
-  s[0] = 0
+  regentlib.assert(x[0] == 1, "test failed")
+  x[0] = 0
   regentlib.assert(s[0] == 0, "test failed")
 end
 regentlib.start(main)


### PR DESCRIPTION
This is not ready for merge. Issues:

Doesn't support `__fields` or `__physical`. It would need to know the privileges on the fields during type checking, but that information is now calculated later. Breaking the circular dependency probably wouldn't be too difficult, but it would be annoying to have to go back and fix up the type checked AST after finding the privileges. One failing test case is `run_pass/call_terra_region.rg`.

Index launch checking is less complete. I didn't get around to implementing the check to see if two regions are always distinct for all pairs of iterations. This would just need some metadata to tell if a parent region was declared outside the loop. A failing test case is `run_pass/optimize_index_launch_num.rg`.

`flow_from_ast.t` still tries to use the old constraint data, even though it isn't there anymore. It hasn't been converted to using the new interface for getting constraint information. This makes `run_pass/parallelize_tasks_hint_color_space.rg` fail, among others.