### PR TITLE
Selectively export tasks in save_tasks.

### DIFF
--- a/language/examples/embed_tasks.rg
+++ b/language/examples/embed_tasks.rg
@@ -24,9 +24,16 @@ local c = terralib.includec("embed.h", {"-I", root_dir})
 
 local fs = c.fs -- Get the field space from C header
 
+task unexposed_task(r : region(ispace(int1d), fs), p : partition(disjoint, r, ispace(int1d)))
+  regentlib.c.printf("Unexposed task!\n")
+end
+
+
 task my_regent_task(r : region(ispace(int1d), fs), x : int, y : double, z : bool)
 where reads writes(r.{x, y}), reads(r.z) do
-  regentlib.c.printf("Hello from Regent! (values %d %e %d)\n", x, y, z)
+    regentlib.c.printf("Hello from Regent! (values %d %e %d)\n", x, y, z)
+    var p = partition(equal, r, ispace(int1d, 2))
+    unexposed_task(r, p)
 end
 
 
@@ -47,7 +54,11 @@ else
   os.remove(tmpfile)  -- remove this now that we have our directory
 end
 
+local task_whitelist = {}
+task_whitelist[my_regent_task] = true
+task_whitelist[other_regent_task] = true
+
 local embed_tasks_h = embed_tasks_dir .. "embed_tasks.h"
 local embed_tasks_so = embed_tasks_dir .. "libembed_tasks.so"
-regentlib.save_tasks(embed_tasks_h, embed_tasks_so, nil, nil, "embed_tasks_register")
+regentlib.save_tasks(embed_tasks_h, embed_tasks_so, nil, nil, "embed_tasks_register", task_whitelist)
 return embed_tasks_dir

--- a/language/examples/embed_tasks.rg
+++ b/language/examples/embed_tasks.rg
@@ -31,9 +31,9 @@ end
 
 task my_regent_task(r : region(ispace(int1d), fs), x : int, y : double, z : bool)
 where reads writes(r.{x, y}), reads(r.z) do
-    regentlib.c.printf("Hello from Regent! (values %d %e %d)\n", x, y, z)
-    var p = partition(equal, r, ispace(int1d, 2))
-    unexposed_task(r, p)
+  regentlib.c.printf("Hello from Regent! (values %d %e %d)\n", x, y, z)
+  var p = partition(equal, r, ispace(int1d, 2))
+  unexposed_task(r, p)
 end
 
 
@@ -55,8 +55,8 @@ else
 end
 
 local task_whitelist = {}
-task_whitelist[my_regent_task] = true
-task_whitelist[other_regent_task] = true
+task_whitelist["my_regent_task"] = my_regent_task
+task_whitelist["other_regent_task"] = other_regent_task
 
 local embed_tasks_h = embed_tasks_dir .. "embed_tasks.h"
 local embed_tasks_so = embed_tasks_dir .. "libembed_tasks.so"

--- a/language/src/common/data.t
+++ b/language/src/common/data.t
@@ -232,6 +232,16 @@ function data.set(list)
   return result
 end
 
+function data.contains(set, elem)
+  for k, _ in pairs(set) do
+    if k == elem then
+      return true
+    end
+  end
+  return false
+end
+
+
 -- #####################################
 -- ## Tuples
 -- #################

--- a/language/src/common/data.t
+++ b/language/src/common/data.t
@@ -224,21 +224,22 @@ function data.dict(list)
   return result
 end
 
+function data.find_key(dict, val)
+  -- given a value find the key
+  for k, v in pairs(dict) do
+    if v == val then
+      return k
+    end
+  end
+  return nil
+end
+
 function data.set(list)
   local result = {}
   for _, k in ipairs(list) do
     result[k] = true
   end
   return result
-end
-
-function data.contains(set, elem)
-  for k, _ in pairs(set) do
-    if k == elem then
-      return true
-    end
-  end
-  return false
 end
 
 

--- a/language/src/regent/std.t
+++ b/language/src/regent/std.t
@@ -4438,7 +4438,7 @@ end
 local function generate_task_interfaces(task_whitelist)
   local tasks = {}
   for _, variant in ipairs(variants) do
-    if task_whitelist and data.contains(task_whitelist, variant.task) then
+    if task_whitelist and data.find_key(task_whitelist, variant.task) then
       tasks[variant.task] = true
     elseif not task_whitelist then
       tasks[variant.task] = true

--- a/language/src/regent/std.t
+++ b/language/src/regent/std.t
@@ -4434,10 +4434,15 @@ function std.saveobj(main_task, filename, filetype, extra_setup_thunk, link_flag
   profile.print_summary()
 end
 
-local function generate_task_interfaces()
+
+local function generate_task_interfaces(task_whitelist)
   local tasks = {}
   for _, variant in ipairs(variants) do
-    tasks[variant.task] = true
+    if task_whitelist and data.contains(task_whitelist, variant.task) then
+      tasks[variant.task] = true
+    elseif not task_whitelist then
+      tasks[variant.task] = true
+    end
   end
 
   local task_c_iface = terralib.newlist()
@@ -4446,6 +4451,7 @@ local function generate_task_interfaces()
   for task, _ in pairs(tasks) do
     task_c_iface:insert(header_helper.generate_task_c_interface(task))
     task_cxx_iface:insert(header_helper.generate_task_cxx_interface(task))
+
     local definitions = header_helper.generate_task_implementation(task)
     for _, definition in ipairs(definitions) do
       task_impl[definition[1]] = definition[2]
@@ -4503,12 +4509,12 @@ void %s(void);
   header_basename)
 end
 
-local function write_header(header_filename, registration_name)
+local function write_header(header_filename, registration_name, task_whitelist)
   if not registration_name then
     registration_name = header_helper.normalize_name(header_filename) .. "_register"
   end
 
-  local task_c_iface, task_cxx_iface, task_impl = generate_task_interfaces()
+  local task_c_iface, task_cxx_iface, task_impl = generate_task_interfaces(task_whitelist)
 
   local header = io.open(header_filename, "w")
   assert(header)
@@ -4518,10 +4524,10 @@ local function write_header(header_filename, registration_name)
   return registration_name, task_impl
 end
 
-function std.save_tasks(header_filename, filename, filetype, link_flags, registration_name)
+function std.save_tasks(header_filename, filename, filetype, link_flags, registration_name, task_whitelist)
   assert(header_filename and filename)
   local task_wrappers = make_task_wrappers()
-  local registration_name, task_impl = write_header(header_filename, registration_name)
+  local registration_name, task_impl = write_header(header_filename, registration_name, task_whitelist)
   local _, names = std.setup(nil, nil, task_wrappers, registration_name)
   local use_cmake = os.getenv("USE_CMAKE") == "1"
   local lib_dir = os.getenv("LG_RT_DIR") .. "/../bindings/regent"


### PR DESCRIPTION
Add an optional whitelist argument to regentlib.save_tasks. 
Update embed_tasks.rg with a task that takes a partition as an argument to show that its not being exported in the header file, but still in the shared library and callable from other tasks. 