### PR TITLE
GASNet: add build with UCX conduit

### DIFF
--- a/cmake/FindGASNet.cmake
+++ b/cmake/FindGASNet.cmake
@@ -279,7 +279,7 @@ if(NOT GASNet_FOUND AND NOT TARGET GASNet::GASNet)
   if(GASNet_FOUND)
     # Reorder preferred conduits to place local preferences first
     set(GASNet_ALL_PREFERRED_CONDUITS
-      "mxm;psm;gemini;aries;pami;ibv;shmem;portals4;ofi;mpi;udp;smp")
+      "mxm;psm;gemini;aries;pami;ibv;shmem;portals4;ofi;mpi;udp;smp,ucx")
     set(GASNet_PREFERRED_CONDUITS "${GASNet_ALL_PREFERRED_CONDUITS}"
       CACHE STRING "")
     mark_as_advanced(GASNet_PREFERRED_CONDUITS)

--- a/cmake/realm_defines.h.in
+++ b/cmake/realm_defines.h.in
@@ -41,6 +41,7 @@
 #cmakedefine GASNET_CONDUIT_ARIES 1
 #cmakedefine GASNET_CONDUIT_GEMINI 1
 #cmakedefine GASNET_CONDUIT_PSM 1
+#cmakedefine GASNET_CONDUIT_UCX 1
 
 #cmakedefine REALM_USE_MPI
 

--- a/runtime/runtime.mk
+++ b/runtime/runtime.mk
@@ -501,7 +501,7 @@ ifneq ($(findstring gasnet1,$(REALM_NETWORKS)),)
   # Detect conduit, if requested
   CONDUIT ?= auto
   ifeq ($(strip $(CONDUIT)),auto)
-    GASNET_PREFERRED_CONDUITS = ibv aries gemini pami mpi udp ofi psm mxm portals4 smp
+    GASNET_PREFERRED_CONDUITS = ibv aries gemini pami mpi udp ofi psm mxm portals4 smp ucx
     GASNET_LIBS_FOUND := $(wildcard $(GASNET_PREFERRED_CONDUITS:%=$(GASNET)/lib/libgasnet-%-par.*))
     ifeq ($(strip $(GASNET_LIBS_FOUND)),)
       $(error No multi-threaded GASNet conduits found in $(GASNET)/lib!)
@@ -529,6 +529,13 @@ ifneq ($(findstring gasnet1,$(REALM_NETWORKS)),)
     INC_FLAGS 	+= -I$(GASNET)/include/ibv-conduit
     REALM_CC_FLAGS	+= -DGASNET_CONDUIT_IBV
     LEGION_LD_FLAGS	+= -lgasnet-ibv-par -libverbs
+    # GASNet needs MPI for interop support
+    USE_MPI	= 1
+  endif
+  ifeq ($(strip $(CONDUIT)),ucx)
+    INC_FLAGS 	+= -I$(GASNET)/include/ucx-conduit
+    REALM_CC_FLAGS	+= -DGASNET_CONDUIT_UCX
+    LEGION_LD_FLAGS	+= -lgasnet-ucx-par -lucp -luct -lucs -lucm
     # GASNet needs MPI for interop support
     USE_MPI	= 1
   endif


### PR DESCRIPTION
This PR adds the use of the UCX-conduit which was introduced with GASNet-EX 2020.3.0