### PR TITLE
Regent: dynamic check for index launches

### DIFF
--- a/language/src/regent/ast_util.t
+++ b/language/src/regent/ast_util.t
@@ -37,6 +37,16 @@ function ast_util.mk_expr_id(sym, ty)
   }
 end
 
+function ast_util.mk_expr_id_rawref(sym, ty)
+  ty = ty or std.rawref(&sym:gettype())
+  return ast.typed.expr.ID {
+    value = sym,
+    expr_type = ty,
+    span = ast.trivial_span(),
+    annotations = ast.default_annotations(),
+  }
+end
+
 function ast_util.mk_expr_index_access(value, index, ty)
   return ast.typed.expr.IndexAccess {
     value = value,

--- a/language/src/regent/ast_util.t
+++ b/language/src/regent/ast_util.t
@@ -20,6 +20,13 @@ local std = require("regent/std")
 
 local ast_util = {}
 
+function ast_util.mk_stat_break()
+  return ast.typed.stat.Break {
+    span = ast.trivial_span(),
+    annotations = ast.default_annotations()
+  }
+end
+
 function ast_util.mk_expr_id(sym, ty)
   ty = ty or sym:gettype()
   return ast.typed.expr.ID {
@@ -297,6 +304,17 @@ function ast_util.mk_stat_if(cond, stat)
   }
 end
 
+function ast_util.mk_stat_if_else(cond, then_stats, else_stats)
+  return ast.typed.stat.If {
+    cond = cond,
+    then_block = ast_util.mk_block(then_stats),
+    elseif_blocks = terralib.newlist(),
+    else_block = ast_util.mk_block(else_stats),
+    span = ast.trivial_span(),
+    annotations = ast.default_annotations(),
+  }
+end
+
 function ast_util.mk_stat_elseif(cond, stat)
   return ast.typed.stat.Elseif {
     cond = cond,
@@ -335,6 +353,17 @@ function ast_util.mk_stat_for_list(symbol, value, block)
     metadata = false,
     span = ast.trivial_span(),
     annotations = ast.default_annotations(),
+  }
+end
+
+function ast_util.mk_stat_for_num(symbol, values, block)
+  return ast.typed.stat.ForNum {
+    block = block,
+    values = values,
+    symbol = symbol,
+    metadata = false,
+    span = ast.trivial_span(),
+    annotations = ast.default_annotations()
   }
 end
 

--- a/language/src/regent/ast_util.t
+++ b/language/src/regent/ast_util.t
@@ -113,6 +113,16 @@ function ast_util.mk_expr_binary(op, lhs, rhs)
   }
 end
 
+function ast_util.mk_expr_method_call(value, expr_type, method_name, args)
+  return ast.typed.expr.MethodCall {
+    value = value,
+    expr_type = expr_type,
+    method_name = method_name,
+    args = args,
+    span = ast.trivial_span(),
+    annotations = ast.default_annotations()
+  }
+end
 function ast_util.mk_expr_call(fn, args, replicable)
   args = args or terralib.newlist()
   if not terralib.islist(args) then

--- a/language/src/regent/config.t
+++ b/language/src/regent/config.t
@@ -96,6 +96,7 @@ local default_options = {
   ["no-dynamic-branches"] = true,
   ["no-dynamic-branches-assert"] = false,
   ["override-demand-index-launch"] = false,
+  ["index-launch-dynamic"] = true,
   ["override-demand-openmp"] = false,
   ["override-demand-cuda"] = false,
   ["allow-loop-demand-parallel"] = false,

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1212,9 +1212,8 @@ local function get_check_stats(preamble, value, index_expr, bitmask, conflict, v
   local bitmask_assign_true = util.mk_stat_assignment(bitmask_value, util.mk_expr_constant(true, bool)) 
   then_block:insert(bitmask_assign_true)
 
-  local save_pos = util.mk_stat_assignment(util.mk_expr_id_rawref(pos), util.mk_expr_id(loop_var))
   local set_verdict = util.mk_stat_assignment(util.mk_expr_id_rawref(verdict), util.mk_expr_constant(true, bool))
-  local check_conflict = util.mk_stat_if(util.mk_expr_id(conflict), terralib.newlist { save_pos, set_verdict, util.mk_stat_break() })
+  local check_conflict = util.mk_stat_if(util.mk_expr_id(conflict), terralib.newlist { set_verdict, util.mk_stat_break() })
   then_block:insert(check_conflict)
 
   local cond = util.mk_expr_binary("<", util.mk_expr_id(value), util.mk_expr_id(volume))

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1198,10 +1198,11 @@ function init_bitmask_false(bitmask)
   return util.mk_stat_for_num(idx, values, util.mk_block(stats))
 end
 
-function get_check_stats(bitmask, value, conflict, index_expr, volume)
+function get_check_stats(preamble, value, index_expr, bitmask, conflict, volume)
   local stats = terralib.newlist()
 
   -- Compute value = index_expr(i)
+  preamble:map(function(stat) stats:insert(stat) end)
   stats:insert(util.mk_stat_assignment(util.mk_expr_id_rawref(value), index_expr))
 
   local then_block = terralib.newlist()
@@ -1257,7 +1258,7 @@ function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
   else
     index_expr = index_launch_ast.call.args[1].index
   end
-  local check_stats = get_check_stats(bitmask, value, conflict, index_expr, volume)
+  local check_stats = get_check_stats(index_launch_ast.preamble, value, index_expr, bitmask, conflict, volume)
 
   local i = index_launch_ast.symbol
   local bounds

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -29,6 +29,11 @@ local emit_dynamic_check = std.config["index-launch-dynamic"]
 
 local context = {}
 
+local function get_source_location(node)
+  assert(node.span.source and node.span.start.line)
+  return tostring(node.span.source) .. ":" .. tostring(node.span.start.line)
+end
+
 function context:__index (field)
   local value = context [field]
   if value ~= nil then
@@ -1219,8 +1224,9 @@ local function mk_duplicates_check(preamble, value, index_expr, bitmask, conflic
   return stats
 end
 
-local function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
+local function insert_dynamic_check(index_launch_ast, unopt_loop_ast)
   local stats = terralib.newlist()
+  --stats:insert(util.mk_block(util.mk_stat_expr(util.mk_expr_call(std.assert_error, terralib.newlist { util.mk_expr_constant(false, bool), util.mk_expr_constant("F", rawstring) }))))
 
   local verdict = std.newsymbol(bool, "verdict")
   stats:insert(util.mk_stat_var(verdict, bool, util.mk_expr_constant(false, bool)))
@@ -1253,9 +1259,9 @@ local function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
       local conflict = std.newsymbol(bool, "conflict")
       stats:insert(util.mk_stat_var(conflict, bool, util.mk_expr_constant(false, bool)))
 
-      local index_expr
       -- Figure out what type of loop we've got and get its index expr
-      if unoptimized_loop_ast.node_type:is(ast.typed.stat.ForNum) then
+      local index_expr
+      if unopt_loop_ast.node_type:is(ast.typed.stat.ForNum) then
         index_expr = arg.index.arg
       else
         index_expr = arg.index
@@ -1266,7 +1272,7 @@ local function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
   
       local bounds
       -- Generate the AST based on loop type
-      if unoptimized_loop_ast.node_type:is(ast.typed.stat.ForNum) then
+      if unopt_loop_ast.node_type:is(ast.typed.stat.ForNum) then
         bounds = index_launch_ast.values
         stats:insert(util.mk_stat_for_num(i, bounds, util.mk_block(duplicates_check)))
       else
@@ -1277,9 +1283,9 @@ local function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
   end
 
   -- Finally check verdict outside the loop to decide if it's safe to launch or not
-  local final_check = util.mk_stat_if_else(util.mk_expr_id(verdict), unoptimized_loop_ast, index_launch_ast)
-  stats:insert(final_check)
-
+  local abort = util.mk_stat_expr(util.mk_expr_call(std.assert_error, terralib.newlist { util.mk_expr_constant(false, bool), util.mk_expr_constant(get_source_location(unopt_loop_ast) .. ": loop ineligible for index launch due to non-injective projection functor", rawstring) }))
+  stats:insert(util.mk_stat_if_else(util.mk_expr_id(verdict), util.mk_stat_block(util.mk_block(abort)), index_launch_ast))
+  
   return util.mk_stat_block(util.mk_block(stats))
 end
 

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -25,6 +25,7 @@ local report = require("common/report")
 local std = require("regent/std")
 
 local skip_interference_check = std.config["override-demand-index-launch"]
+local emit_dynamic_check = std.config["index-launch-dynamic"]
 
 local context = {}
 
@@ -1311,7 +1312,7 @@ function optimize_index_launch.stat_for_num(cx, node)
         span = node.span,
     }
 
-    if not body.needs_dynamic_check then
+    if not emit_dynamic_check or not body.needs_dynamic_check then
       return index_launch_ast
     else
       return insert_dynamic_check(index_launch_ast, node {
@@ -1366,7 +1367,7 @@ function optimize_index_launch.stat_for_list(cx, node)
       span = node.span,
     }
 
-    if not body.needs_dynamic_check then
+    if not emit_dynamic_check or not body.needs_dynamic_check then
       return index_launch_ast
     else
       return insert_dynamic_check(index_launch_ast, node {

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1197,7 +1197,6 @@ function get_check_stats(bitmask, value, conflict, index_expr, volume)
   -- Compute value = index_expr(i)
   stats:insert(util.mk_stat_assignment(util.mk_expr_id_rawref(value), index_expr))
 
-  local cond = util.mk_expr_binary("<", util.mk_expr_id(value), util.mk_expr_id(volume))
   local then_block = terralib.newlist()
 
   local bitmask_value = util.mk_expr_index_access(util.mk_expr_id(bitmask), util.mk_expr_id(value), std.rawref(&bool))
@@ -1210,6 +1209,7 @@ function get_check_stats(bitmask, value, conflict, index_expr, volume)
   local check_conflict = util.mk_stat_if(util.mk_expr_id(conflict), util.mk_stat_break())
   then_block:insert(check_conflict)
 
+  local cond = util.mk_expr_binary("<", util.mk_expr_id(value), util.mk_expr_id(volume))
   local bounds_check = util.mk_stat_if(cond, then_block)
   stats:insert(bounds_check)
 
@@ -1225,7 +1225,7 @@ function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
   local p_bounds = util.mk_expr_field_access(p_colors, "bounds", std.rect1d)
   local p_volume = util.mk_expr_method_call(p_bounds, int32, "volume", terralib.newlist())
   local volume = std.newsymbol(int32, "volume")
-  stats:insert(util.mk_stat_var(volume, nil, p_volume))
+  stats:insert(util.mk_stat_var(volume, int32, p_volume))
 
   -- Set colors = 1e2 for now
   local bitmask = std.newsymbol(bool[1e2], "bitmask")
@@ -1238,12 +1238,18 @@ function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
   local conflict = std.newsymbol(bool, "conflict")
   stats:insert(util.mk_stat_var(conflict, bool, util.mk_expr_constant(false, bool)))
 
-  local index_expr = index_launch_ast.call.args[1].index.arg
+  local index_expr
+  -- Figure out what type of loop we've got and get its index expr
+  if unoptimized_loop_ast.node_type:is(ast.typed.stat.ForNum) then
+    index_expr = index_launch_ast.call.args[1].index.arg
+  else
+    index_expr = index_launch_ast.call.args[1].index
+  end
   local check_stats = get_check_stats(bitmask, value, conflict, index_expr, volume)
 
   local i = index_launch_ast.symbol
   local bounds
-  -- Figure out what type of loop we've got and generate its AST
+  -- Generating the AST based on loop type
   if unoptimized_loop_ast.node_type:is(ast.typed.stat.ForNum) then
     bounds = index_launch_ast.values
     stats:insert(util.mk_stat_for_num(i, bounds, util.mk_block(check_stats)))

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1201,7 +1201,7 @@ function init_bitmask_false(bitmask, volume)
   return util.mk_stat_for_num(idx, values, util.mk_block(stats))
 end
 
-function get_check_stats(preamble, value, index_expr, bitmask, conflict, volume)
+function get_check_stats(preamble, value, index_expr, bitmask, conflict, pos, loop_var, volume)
   local stats = terralib.newlist()
 
   -- Compute value = index_expr(i)
@@ -1217,7 +1217,8 @@ function get_check_stats(preamble, value, index_expr, bitmask, conflict, volume)
   local bitmask_assign_true = util.mk_stat_assignment(bitmask_value, util.mk_expr_constant(true, bool)) 
   then_block:insert(bitmask_assign_true)
 
-  local check_conflict = util.mk_stat_if(util.mk_expr_id(conflict), util.mk_stat_break())
+  local save_pos = util.mk_stat_assignment(util.mk_expr_id_rawref(pos), util.mk_expr_id(loop_var))
+  local check_conflict = util.mk_stat_if(util.mk_expr_id(conflict), terralib.newlist { save_pos, util.mk_stat_break() })
   then_block:insert(check_conflict)
 
   local cond = util.mk_expr_binary("<", util.mk_expr_id(value), util.mk_expr_id(volume))
@@ -1257,6 +1258,9 @@ function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
   local conflict = std.newsymbol(bool, "conflict")
   stats:insert(util.mk_stat_var(conflict, bool, util.mk_expr_constant(false, bool)))
 
+  local pos = std.newsymbol(int64, "pos")
+  stats:insert(util.mk_stat_var(pos, int64))
+
   local index_expr
   -- Figure out what type of loop we've got and get its index expr
   if unoptimized_loop_ast.node_type:is(ast.typed.stat.ForNum) then
@@ -1264,9 +1268,10 @@ function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
   else
     index_expr = index_launch_ast.call.args[1].index
   end
-  local check_stats = get_check_stats(index_launch_ast.preamble, value, index_expr, bitmask, conflict, volume)
 
   local i = index_launch_ast.symbol
+  local check_stats = get_check_stats(index_launch_ast.preamble, value, index_expr, bitmask, conflict, pos, i, volume)
+
   local bounds
   -- Generate the AST based on loop type
   if unoptimized_loop_ast.node_type:is(ast.typed.stat.ForNum) then
@@ -1277,7 +1282,7 @@ function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
     stats:insert(util.mk_stat_for_list(i, bounds, util.mk_block(check_stats)))
   end
 
-  -- Finally check conflict outside the loop to decide whether to optimize or not
+  -- Finally check conflict outside the loop to decide if it's safe to launch or not
   local final_check = util.mk_stat_if_else(util.mk_expr_id(conflict), unoptimized_loop_ast, index_launch_ast)
   stats:insert(final_check)
 

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -474,6 +474,9 @@ local function analyze_noninterference_self(
     if analyze_index_noninterference_self(index, cx, loop_vars)
     then
       return true
+    else
+      local needs_dynamic_check = true
+      return false, needs_dynamic_check
     end
   end
 
@@ -1136,10 +1139,10 @@ local function optimize_loop_body(cx, node, report_pass, report_fail)
         end
 
         do
-          local passed = analyze_noninterference_self(
+          local passed, needs_dynamic_check = analyze_noninterference_self(
             loop_cx, task, arg, partition_type, mapping, loop_vars)
           if not passed then
-            if emit_dynamic_check then
+            if emit_dynamic_check and needs_dynamic_check then
               report_pass(call, "static loop optimization failed, emitting dynamic check")
               return {
                 preamble = preamble,

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1226,8 +1226,13 @@ end
 function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
   local stats = terralib.newlist()
 
-  -- Generating the AST for var volume = p.colors.bounds:volume()
-  local p_symbol = index_launch_ast.call.args[1].value.value
+  -- Optimize only if we are indexing into a partition
+  local proceed, p_symbol = pcall(function() return index_launch_ast.call.args[1].value.value end)
+  if not proceed then
+    return unoptimized_loop_ast
+  end
+
+  -- Generate the AST for var volume = p.colors.bounds:volume()
   local p_colors = util.mk_expr_field_access(util.mk_expr_id(p_symbol), "colors", std.ispace(std.int1d))
   local p_bounds = util.mk_expr_field_access(p_colors, "bounds", std.rect1d)
   local p_volume = util.mk_expr_method_call(p_bounds, int32, "volume", terralib.newlist())
@@ -1256,7 +1261,7 @@ function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
 
   local i = index_launch_ast.symbol
   local bounds
-  -- Generating the AST based on loop type
+  -- Generate the AST based on loop type
   if unoptimized_loop_ast.node_type:is(ast.typed.stat.ForNum) then
     bounds = index_launch_ast.values
     stats:insert(util.mk_stat_for_num(i, bounds, util.mk_block(check_stats)))
@@ -1269,9 +1274,7 @@ function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
   local final_check = util.mk_stat_if_else(util.mk_expr_id(conflict), unoptimized_loop_ast, index_launch_ast)
   stats:insert(final_check)
 
-  local block = util.mk_block(stats)
-  local stat_block = util.mk_stat_block(block)
-  return stat_block
+  return util.mk_stat_block(util.mk_block(stats))
 end
 
 function optimize_index_launch.stat_for_num(cx, node)

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -473,7 +473,7 @@ local function analyze_noninterference_self(
       (arg:is(ast.typed.expr.Projection) and arg.region.index) or arg.index
     if analyze_index_noninterference_self(index, cx, loop_vars)
     then
-      return true
+      return true, false
     else
       local needs_dynamic_check = true
       return false, needs_dynamic_check
@@ -1186,8 +1186,7 @@ local function init_bitmask(bitmask, volume)
 
   local idx = std.newsymbol(int32, "i")
   local bitmask_i = util.mk_expr_index_access(util.mk_expr_id_rawref(bitmask), util.mk_expr_id(idx), std.rawref(&bool))
-  local assign = util.mk_stat_assignment(bitmask_i, util.mk_expr_constant(false, bool))
-  stats:insert(assign)
+  stats:insert(util.mk_stat_assignment(bitmask_i, util.mk_expr_constant(false, bool)))
 
   local values = terralib.newlist()
   values:insert(util.mk_expr_constant(0, int32))
@@ -1196,7 +1195,7 @@ local function init_bitmask(bitmask, volume)
   return util.mk_stat_for_num(idx, values, util.mk_block(stats))
 end
 
-local function get_check_stats(preamble, value, index_expr, bitmask, conflict, verdict, pos, loop_var, volume)
+local function mk_duplicates_check(preamble, value, index_expr, bitmask, conflict, verdict, loop_var, volume)
   local stats = terralib.newlist()
 
   -- Compute value = index_expr(i)
@@ -1206,19 +1205,16 @@ local function get_check_stats(preamble, value, index_expr, bitmask, conflict, v
   local then_block = terralib.newlist()
 
   local bitmask_value = util.mk_expr_index_access(util.mk_expr_id(bitmask), util.mk_expr_id(value), std.rawref(&bool))
-  local conflict_assign = util.mk_stat_assignment(util.mk_expr_id_rawref(conflict), bitmask_value)
-  then_block:insert(conflict_assign)
+  then_block:insert(util.mk_stat_assignment(util.mk_expr_id_rawref(conflict), bitmask_value))
 
-  local bitmask_assign_true = util.mk_stat_assignment(bitmask_value, util.mk_expr_constant(true, bool)) 
-  then_block:insert(bitmask_assign_true)
+  then_block:insert(util.mk_stat_assignment(bitmask_value, util.mk_expr_constant(true, bool)) )
 
   local set_verdict = util.mk_stat_assignment(util.mk_expr_id_rawref(verdict), util.mk_expr_constant(true, bool))
-  local check_conflict = util.mk_stat_if(util.mk_expr_id(conflict), terralib.newlist { set_verdict, util.mk_stat_break() })
-  then_block:insert(check_conflict)
+  then_block:insert(util.mk_stat_if(util.mk_expr_id(conflict), terralib.newlist { set_verdict, util.mk_stat_break() }))
 
+  -- Bounds check
   local cond = util.mk_expr_binary("<", util.mk_expr_id(value), util.mk_expr_id(volume))
-  local bounds_check = util.mk_stat_if(cond, then_block)
-  stats:insert(bounds_check)
+  stats:insert(util.mk_stat_if(cond, then_block))
 
   return stats
 end
@@ -1230,7 +1226,12 @@ local function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
   stats:insert(util.mk_stat_var(verdict, bool, util.mk_expr_constant(false, bool)))
 
   for _, arg in pairs(index_launch_ast.call.args) do
-    if pcall (function() std.is_partition(std.as_read(arg.value.expr_type)) end) and (arg.expr_type:ispace().dim == 1) then
+    -- Skip non-partition args
+    if arg:is(ast.typed.expr.IndexAccess) and
+       std.is_region(arg.expr_type) and
+       std.is_partition(std.as_read(arg.value.expr_type)) and
+       (arg.expr_type:ispace().dim == 1) then
+
       -- Generate the AST for var volume = p.colors.bounds:volume()
       local p_colors = util.mk_expr_field_access(util.mk_expr_id(arg.value.value), "colors", std.ispace(std.int1d))
       local p_bounds = util.mk_expr_field_access(p_colors, "bounds", std.rect1d)
@@ -1252,9 +1253,6 @@ local function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
       local conflict = std.newsymbol(bool, "conflict")
       stats:insert(util.mk_stat_var(conflict, bool, util.mk_expr_constant(false, bool)))
 
-      local pos = std.newsymbol(int64, "pos")
-      stats:insert(util.mk_stat_var(pos, int64))
-  
       local index_expr
       -- Figure out what type of loop we've got and get its index expr
       if unoptimized_loop_ast.node_type:is(ast.typed.stat.ForNum) then
@@ -1264,16 +1262,16 @@ local function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
       end
   
       local i = index_launch_ast.symbol
-      local check_stats = get_check_stats(index_launch_ast.preamble, value, index_expr, bitmask, conflict, verdict, pos, i, volume)
+      local duplicates_check = mk_duplicates_check(index_launch_ast.preamble, value, index_expr, bitmask, conflict, verdict, i, volume)
   
       local bounds
       -- Generate the AST based on loop type
       if unoptimized_loop_ast.node_type:is(ast.typed.stat.ForNum) then
         bounds = index_launch_ast.values
-        stats:insert(util.mk_stat_for_num(i, bounds, util.mk_block(check_stats)))
+        stats:insert(util.mk_stat_for_num(i, bounds, util.mk_block(duplicates_check)))
       else
         bounds = index_launch_ast.value
-        stats:insert(util.mk_stat_for_list(i, bounds, util.mk_block(check_stats)))
+        stats:insert(util.mk_stat_for_list(i, bounds, util.mk_block(duplicates_check)))
       end
     end
   end

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1008,6 +1008,7 @@ local function optimize_loop_body(cx, node, report_pass, report_fail)
   }
 
   local free_vars = terralib.newlist()
+  local needs_dynamic_check = false
 
   -- Perform a simpler analysis if the expression is not a task launch
   if not call:is(ast.typed.expr.Call) then
@@ -1139,22 +1140,11 @@ local function optimize_loop_body(cx, node, report_pass, report_fail)
         end
 
         do
-          local passed, needs_dynamic_check = analyze_noninterference_self(
+          local passed
+          passed, needs_dynamic_check = analyze_noninterference_self(
             loop_cx, task, arg, partition_type, mapping, loop_vars)
           if not passed then
-            if emit_dynamic_check and needs_dynamic_check then
-              report_pass(call, "static loop optimization failed, emitting dynamic check")
-              return {
-                preamble = preamble,
-                call = call,
-                reduce_lhs = reduce_lhs,
-                reduce_op = reduce_op,
-                args_provably = args_provably,
-                free_variables = free_vars,
-                loop_variables = loop_vars,
-                needs_dynamic_check = true
-              }
-            else
+            if not (emit_dynamic_check and needs_dynamic_check) then
               report_fail(call, "loop optimization failed: argument " .. tostring(i) ..
                 " interferes with itself")
               return
@@ -1173,7 +1163,12 @@ local function optimize_loop_body(cx, node, report_pass, report_fail)
     end
   end
 
-  report_pass("loop optimization succeeded")
+  if needs_dynamic_check then
+    report_pass("static loop optimization failed, emitting dynamic check")
+  else
+    report_pass("loop optimization succeeded")
+  end
+
   return {
     preamble = preamble,
     call = call,
@@ -1182,7 +1177,7 @@ local function optimize_loop_body(cx, node, report_pass, report_fail)
     args_provably = args_provably,
     free_variables = free_vars,
     loop_variables = loop_vars,
-    needs_dynamic_check = false
+    needs_dynamic_check = needs_dynamic_check
   }
 end
 

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1186,7 +1186,7 @@ local function optimize_loop_body(cx, node, report_pass, report_fail)
   }
 end
 
-function init_bitmask_false(bitmask)
+function init_bitmask_false(bitmask, volume)
   local stats = terralib.newlist()
 
   local idx = std.newsymbol(int32, "i")
@@ -1196,7 +1196,7 @@ function init_bitmask_false(bitmask)
 
   local values = terralib.newlist()
   values:insert(util.mk_expr_constant(0, int32))
-  values:insert(util.mk_expr_constant(1e2, int32))
+  values:insert(util.mk_expr_id(volume))
 
   return util.mk_stat_for_num(idx, values, util.mk_block(stats))
 end
@@ -1243,10 +1243,13 @@ function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
   local volume = std.newsymbol(int32, "volume")
   stats:insert(util.mk_stat_var(volume, int32, p_volume))
 
-  -- Set colors = 1e2 for now
-  local bitmask = std.newsymbol(bool[1e2], "bitmask")
-  stats:insert(util.mk_stat_var(bitmask, bool[1e2], false))
-  stats:insert(init_bitmask_false(bitmask))
+  -- Malloc a bitmask of size volume and initialize it
+  local bitmask_raw = std.newsymbol(&opaque, "bitmask_raw")
+  local bitmask = std.newsymbol(&bool, "bitmask")
+  local malloc_call = util.mk_expr_call(std.c.malloc, util.mk_expr_cast(uint64, util.mk_expr_id(volume)))
+  stats:insert(util.mk_stat_var(bitmask_raw, &opaque, malloc_call))
+  stats:insert(util.mk_stat_var(bitmask, &bool, util.mk_expr_cast(&bool, util.mk_expr_id(bitmask_raw))))
+  stats:insert(init_bitmask_false(bitmask, volume))
 
   local value = std.newsymbol(int64, "value")
   stats:insert(util.mk_stat_var(value, int64))

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1138,9 +1138,17 @@ local function optimize_loop_body(cx, node, report_pass, report_fail)
           local passed = analyze_noninterference_self(
             loop_cx, task, arg, partition_type, mapping, loop_vars)
           if not passed then
-            ignore(call, "static loop optimization failed: argument " .. tostring(i) ..
-                " interferes with itself")
-            return
+            report_pass(call, "static loop optimization failed, emitting dynamic check")
+            return {
+              preamble = preamble,
+              call = call,
+              reduce_lhs = reduce_lhs,
+              reduce_op = reduce_op,
+              args_provably = args_provably,
+              free_variables = free_vars,
+              loop_variables = loop_vars,
+              needs_dynamic_check = true
+            }
           end
         end
       end
@@ -1163,7 +1171,8 @@ local function optimize_loop_body(cx, node, report_pass, report_fail)
     reduce_op = reduce_op,
     args_provably = args_provably,
     free_variables = free_vars,
-    loop_variables = loop_vars
+    loop_variables = loop_vars,
+    needs_dynamic_check = false
   }
 end
 
@@ -1263,33 +1272,37 @@ function optimize_index_launch.stat_for_num(cx, node)
     return node
   end
 
-  local needs_dynamic_check = false
   local body = optimize_loop_body(cx, node, report_pass, report_fail)
   if not body then
-    needs_dynamic_check = true
-  end
-
-  local index_launch_ast = ast.typed.stat.IndexLaunchNum {
-    symbol = node.symbol,
-    values = node.values,
-    preamble = body.preamble,
-    call = body.call,
-    reduce_lhs = body.reduce_lhs,
-    reduce_op = body.reduce_op,
-    reduce_task = false,
-    args_provably = body.args_provably,
-    free_vars = body.free_variables,
-    loop_vars = body.loop_variables,
-    annotations = node.annotations,
-    span = node.span,
-  }
-
-  if needs_dynamic_check then
-    return insert_dynamic_check(index_launch_ast, node {
-      block = optimize_index_launches.block(cx, node.block)
-      })
+    return node {
+      block = optimize_index_launches.block(cx, node.block),
+    }
   else
-    return index_launch_ast
+    -- If we reach here then either the self interference test failed, 
+    -- or the optimization was successful. body.needs_dynamic_check
+    -- will tell us which it is.
+    local index_launch_ast = ast.typed.stat.IndexLaunchNum {
+        symbol = node.symbol,
+        values = node.values,
+        preamble = body.preamble,
+        call = body.call,
+        reduce_lhs = body.reduce_lhs,
+        reduce_op = body.reduce_op,
+        reduce_task = false,
+        args_provably = body.args_provably,
+        free_vars = body.free_variables,
+        loop_vars = body.loop_variables,
+        annotations = node.annotations,
+        span = node.span,
+    }
+
+    if not body.needs_dynamic_check then
+      return index_launch_ast
+    else
+      return insert_dynamic_check(index_launch_ast, node {
+        block = optimize_index_launches.block(cx, node.block),
+      })
+    end
   end
 end
 
@@ -1317,30 +1330,35 @@ function optimize_index_launch.stat_for_list(cx, node)
   local needs_dynamic_check = false
   local body = optimize_loop_body(cx, node, report_pass, report_fail)
   if not body then
-    needs_dynamic_check = true
-  end
-
-  local index_launch_ast = ast.typed.stat.IndexLaunchList {
-    symbol = node.symbol,
-    value = node.value,
-    preamble = body.preamble,
-    call = body.call,
-    reduce_lhs = body.reduce_lhs,
-    reduce_op = body.reduce_op,
-    reduce_task = false,
-    args_provably = body.args_provably,
-    free_vars = body.free_variables,
-    loop_vars = body.loop_variables,
-    annotations = node.annotations,
-    span = node.span,
-  }
-
-  if needs_dynamic_check then
-    return insert_dynamic_check(index_launch_ast, node {
-      block = optimize_index_launches.block(cx, node.block)
-      })
+    return node {
+      block = optimize_index_launches.block(cx, node.block),
+    }
   else
-    return index_launch_ast
+    -- If we reach here then either the self interference test failed, 
+    -- or the optimization was successful. body.needs_dynamic_check
+    -- will tell us which it is.
+    local index_launch_ast = ast.typed.stat.IndexLaunchList {
+      symbol = node.symbol,
+      value = node.value,
+      preamble = body.preamble,
+      call = body.call,
+      reduce_lhs = body.reduce_lhs,
+      reduce_op = body.reduce_op,
+      reduce_task = false,
+      args_provably = body.args_provably,
+      free_vars = body.free_variables,
+      loop_vars = body.loop_variables,
+      annotations = node.annotations,
+      span = node.span,
+    }
+
+    if not body.needs_dynamic_check then
+      return index_launch_ast
+    else
+      return insert_dynamic_check(index_launch_ast, node {
+        block = optimize_index_launches.block(cx, node.block),
+      })
+    end
   end
 end
 

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1181,7 +1181,7 @@ local function optimize_loop_body(cx, node, report_pass, report_fail)
   }
 end
 
-function init_bitmask_false(bitmask, volume)
+local function init_bitmask(bitmask, volume)
   local stats = terralib.newlist()
 
   local idx = std.newsymbol(int32, "i")
@@ -1196,7 +1196,7 @@ function init_bitmask_false(bitmask, volume)
   return util.mk_stat_for_num(idx, values, util.mk_block(stats))
 end
 
-function get_check_stats(preamble, value, index_expr, bitmask, conflict, pos, loop_var, volume)
+local function get_check_stats(preamble, value, index_expr, bitmask, conflict, verdict, pos, loop_var, volume)
   local stats = terralib.newlist()
 
   -- Compute value = index_expr(i)
@@ -1213,7 +1213,8 @@ function get_check_stats(preamble, value, index_expr, bitmask, conflict, pos, lo
   then_block:insert(bitmask_assign_true)
 
   local save_pos = util.mk_stat_assignment(util.mk_expr_id_rawref(pos), util.mk_expr_id(loop_var))
-  local check_conflict = util.mk_stat_if(util.mk_expr_id(conflict), terralib.newlist { save_pos, util.mk_stat_break() })
+  local set_verdict = util.mk_stat_assignment(util.mk_expr_id_rawref(verdict), util.mk_expr_constant(true, bool))
+  local check_conflict = util.mk_stat_if(util.mk_expr_id(conflict), terralib.newlist { save_pos, set_verdict, util.mk_stat_break() })
   then_block:insert(check_conflict)
 
   local cond = util.mk_expr_binary("<", util.mk_expr_id(value), util.mk_expr_id(volume))
@@ -1223,62 +1224,63 @@ function get_check_stats(preamble, value, index_expr, bitmask, conflict, pos, lo
   return stats
 end
 
-function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
+local function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
   local stats = terralib.newlist()
 
-  -- Optimize only if we are indexing into a partition
-  local proceed, p_symbol = pcall(function() return index_launch_ast.call.args[1].value.value end)
-  if not proceed then
-    return unoptimized_loop_ast
+  local verdict = std.newsymbol(bool, "verdict")
+  stats:insert(util.mk_stat_var(verdict, bool, util.mk_expr_constant(false, bool)))
+
+  for _, arg in pairs(index_launch_ast.call.args) do
+    if pcall (function() std.is_partition(std.as_read(arg.value.expr_type)) end) and (arg.expr_type:ispace().dim == 1) then
+      -- Generate the AST for var volume = p.colors.bounds:volume()
+      local p_colors = util.mk_expr_field_access(util.mk_expr_id(arg.value.value), "colors", std.ispace(std.int1d))
+      local p_bounds = util.mk_expr_field_access(p_colors, "bounds", std.rect1d)
+      local p_volume = util.mk_expr_method_call(p_bounds, int32, "volume", terralib.newlist())
+      local volume = std.newsymbol(int32, "volume")
+      stats:insert(util.mk_stat_var(volume, int32, p_volume))
+  
+      -- Malloc a bitmask of size volume and initialize it
+      local bitmask_raw = std.newsymbol(&opaque, "bitmask_raw")
+      local bitmask = std.newsymbol(&bool, "bitmask")
+      local malloc_call = util.mk_expr_call(std.c.malloc, util.mk_expr_cast(uint64, util.mk_expr_id(volume)))
+      stats:insert(util.mk_stat_var(bitmask_raw, &opaque, malloc_call))
+      stats:insert(util.mk_stat_var(bitmask, &bool, util.mk_expr_cast(&bool, util.mk_expr_id(bitmask_raw))))
+      stats:insert(init_bitmask(bitmask, volume))
+  
+      local value = std.newsymbol(int64, "value")
+      stats:insert(util.mk_stat_var(value, int64))
+  
+      local conflict = std.newsymbol(bool, "conflict")
+      stats:insert(util.mk_stat_var(conflict, bool, util.mk_expr_constant(false, bool)))
+
+      local pos = std.newsymbol(int64, "pos")
+      stats:insert(util.mk_stat_var(pos, int64))
+  
+      local index_expr
+      -- Figure out what type of loop we've got and get its index expr
+      if unoptimized_loop_ast.node_type:is(ast.typed.stat.ForNum) then
+        index_expr = arg.index.arg
+      else
+        index_expr = arg.index
+      end
+  
+      local i = index_launch_ast.symbol
+      local check_stats = get_check_stats(index_launch_ast.preamble, value, index_expr, bitmask, conflict, verdict, pos, i, volume)
+  
+      local bounds
+      -- Generate the AST based on loop type
+      if unoptimized_loop_ast.node_type:is(ast.typed.stat.ForNum) then
+        bounds = index_launch_ast.values
+        stats:insert(util.mk_stat_for_num(i, bounds, util.mk_block(check_stats)))
+      else
+        bounds = index_launch_ast.value
+        stats:insert(util.mk_stat_for_list(i, bounds, util.mk_block(check_stats)))
+      end
+    end
   end
 
-  -- Generate the AST for var volume = p.colors.bounds:volume()
-  local p_colors = util.mk_expr_field_access(util.mk_expr_id(p_symbol), "colors", std.ispace(std.int1d))
-  local p_bounds = util.mk_expr_field_access(p_colors, "bounds", std.rect1d)
-  local p_volume = util.mk_expr_method_call(p_bounds, int32, "volume", terralib.newlist())
-  local volume = std.newsymbol(int32, "volume")
-  stats:insert(util.mk_stat_var(volume, int32, p_volume))
-
-  -- Malloc a bitmask of size volume and initialize it
-  local bitmask_raw = std.newsymbol(&opaque, "bitmask_raw")
-  local bitmask = std.newsymbol(&bool, "bitmask")
-  local malloc_call = util.mk_expr_call(std.c.malloc, util.mk_expr_cast(uint64, util.mk_expr_id(volume)))
-  stats:insert(util.mk_stat_var(bitmask_raw, &opaque, malloc_call))
-  stats:insert(util.mk_stat_var(bitmask, &bool, util.mk_expr_cast(&bool, util.mk_expr_id(bitmask_raw))))
-  stats:insert(init_bitmask_false(bitmask, volume))
-
-  local value = std.newsymbol(int64, "value")
-  stats:insert(util.mk_stat_var(value, int64))
-
-  local conflict = std.newsymbol(bool, "conflict")
-  stats:insert(util.mk_stat_var(conflict, bool, util.mk_expr_constant(false, bool)))
-
-  local pos = std.newsymbol(int64, "pos")
-  stats:insert(util.mk_stat_var(pos, int64))
-
-  local index_expr
-  -- Figure out what type of loop we've got and get its index expr
-  if unoptimized_loop_ast.node_type:is(ast.typed.stat.ForNum) then
-    index_expr = index_launch_ast.call.args[1].index.arg
-  else
-    index_expr = index_launch_ast.call.args[1].index
-  end
-
-  local i = index_launch_ast.symbol
-  local check_stats = get_check_stats(index_launch_ast.preamble, value, index_expr, bitmask, conflict, pos, i, volume)
-
-  local bounds
-  -- Generate the AST based on loop type
-  if unoptimized_loop_ast.node_type:is(ast.typed.stat.ForNum) then
-    bounds = index_launch_ast.values
-    stats:insert(util.mk_stat_for_num(i, bounds, util.mk_block(check_stats)))
-  else
-    bounds = index_launch_ast.value
-    stats:insert(util.mk_stat_for_list(i, bounds, util.mk_block(check_stats)))
-  end
-
-  -- Finally check conflict outside the loop to decide if it's safe to launch or not
-  local final_check = util.mk_stat_if_else(util.mk_expr_id(conflict), unoptimized_loop_ast, index_launch_ast)
+  -- Finally check verdict outside the loop to decide if it's safe to launch or not
+  local final_check = util.mk_stat_if_else(util.mk_expr_id(verdict), unoptimized_loop_ast, index_launch_ast)
   stats:insert(final_check)
 
   return util.mk_stat_block(util.mk_block(stats))

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -19,6 +19,7 @@
 
 local affine_helper = require("regent/affine_helper")
 local ast = require("regent/ast")
+local util = require("regent/ast_util")
 local data = require("common/data")
 local report = require("common/report")
 local std = require("regent/std")
@@ -1137,9 +1138,10 @@ local function optimize_loop_body(cx, node, report_pass, report_fail)
           local passed = analyze_noninterference_self(
             loop_cx, task, arg, partition_type, mapping, loop_vars)
           if not passed then
-            report_fail(call, "loop optimization failed: argument " .. tostring(i) ..
+            -- Revert later!
+            ignore(call, "loop optimization failed: argument " .. tostring(i) ..
                 " interferes with itself")
-            return
+            --return
           end
         end
       end
@@ -1164,6 +1166,75 @@ local function optimize_loop_body(cx, node, report_pass, report_fail)
     free_variables = free_vars,
     loop_variables = loop_vars
   }
+end
+
+function mk_stat_for_num(block, values, sym)
+  return ast.typed.stat.ForNum {
+    block = block,
+    values = values,
+    symbol = sym,
+    metadata = false,
+    span = ast.trivial_span(),
+    annotations = ast.default_annotations()
+  }
+end
+
+function init_bitmask(bitmask)
+  local stats = terralib.newlist()
+
+  local idx = std.newsymbol(int32, "i")
+  local bitmask_i = util.mk_expr_index_access(util.mk_expr_id(bitmask, std.rawref(&bitmask:gettype())), util.mk_expr_id(idx), std.rawref(&bool))
+  local assign = util.mk_stat_assignment(bitmask_i, util.mk_expr_constant(false, bool))
+  stats:insert(assign)
+
+  local values = terralib.newlist()
+  values:insert(util.mk_expr_constant(0, int32))
+  values:insert(util.mk_expr_constant(1e2, int32))
+
+  return mk_stat_for_num(util.mk_block(stats), values, idx)
+end
+
+function amaze(node)
+  local p_symbol = node.call.args[1].value.value
+  local index_expr = node.call.args[1].index.arg
+
+  local stats = terralib.newlist()
+  -- Set colors = 1e2 for now
+  
+  local bitmask = std.newsymbol(bool[1e2], "bitmask")
+  stats:insert(util.mk_stat_var(bitmask, bool[1e2], false))
+  stats:insert(init_bitmask(bitmask))
+
+  local value = std.newsymbol(int64, "value")
+  stats:insert(util.mk_stat_var(value, int64, false))
+
+  local conflict = std.newsymbol(bool, "conflict")
+  stats:insert(util.mk_stat_var(conflict, bool, util.mk_expr_constant(false, bool)))
+
+  local bounds = terralib.newlist()
+  bounds:insert(util.mk_expr_constant(0, int32))
+  bounds:insert(util.mk_expr_constant(1e2, int32))
+
+  local i = index_expr.lhs.rhs.value -- FIX LATER
+
+  local loop = terralib.newlist()
+  loop:insert(util.mk_stat_assignment(util.mk_expr_id(value, std.rawref(&int64)), index_expr))
+
+  local cond = util.mk_expr_binary("<", util.mk_expr_id(value), util.mk_expr_constant(100, int32))
+  local then_block = terralib.newlist()
+
+  local bitmask_value = util.mk_expr_index_access(util.mk_expr_id(bitmask), util.mk_expr_id(value), std.rawref(&bool))
+  local assign = util.mk_stat_assignment(util.mk_expr_id(conflict),  bitmask_value)
+  then_block:insert(assign)
+
+  local bounds_check = util.mk_stat_if(cond, then_block)
+  loop:insert(bounds_check)
+
+  stats:insert(mk_stat_for_num(util.mk_block(loop), bounds, i))
+
+  local block = util.mk_block(stats)
+  local stat_block = util.mk_stat_block(block)
+  return stat_block
 end
 
 function optimize_index_launch.stat_for_num(cx, node)
@@ -1193,7 +1264,7 @@ function optimize_index_launch.stat_for_num(cx, node)
     }
   end
 
-  return ast.typed.stat.IndexLaunchNum {
+  local x = ast.typed.stat.IndexLaunchNum {
     symbol = node.symbol,
     values = node.values,
     preamble = body.preamble,
@@ -1204,9 +1275,10 @@ function optimize_index_launch.stat_for_num(cx, node)
     args_provably = body.args_provably,
     free_vars = body.free_variables,
     loop_vars = body.loop_variables,
-    annotations = node.annotations,
+    annotations = ast.default_annotations(), -- REVERT LATER!
     span = node.span,
   }
+  return amaze(x)
 end
 
 function optimize_index_launch.stat_for_list(cx, node)
@@ -1296,6 +1368,7 @@ function optimize_index_launches.top(cx, node)
 end
 
 function optimize_index_launches.entry(node)
+  --print(node.body.stats)
   local cx = context.new_global_scope({})
   return optimize_index_launches.top(cx, node)
 end

--- a/language/tests/regent/compile_fail/optimize_index_launch_list11.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list11.rg
@@ -24,6 +24,11 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+  n: int,
+}
+
 terra e(x : int) : int
   return 3
 end
@@ -32,44 +37,46 @@ terra e_bad(x : c.legion_runtime_t) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r) do
   return 5
 end
 
-task h(r : region(int)) : int
-where reduces +(r) do
+task h(r : region(ispace(int1d), t)) : int
+where reduces +(r.n) do
   return 5
 end
 
-task h2(r : region(int), s : region(int)) : int
-where reduces +(r, s) do
+task h2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
+where reduces +(r.n, s.n) do
   return 5
 end
 
-task h2b(r : region(int), s : region(int)) : int
-where reduces +(r), reduces *(s) do
+task h2b(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
+where reduces +(r.n), reduces *(s.n) do
   return 5
 end
 
 task with_partitions(cs : ispace(int1d),
-                     r0 : region(int), p0_disjoint : partition(disjoint, r0),
-                     r1 : region(int), p1_disjoint : partition(disjoint, r1))
+                     r0 : region(ispace(int1d), t),
+                     p0_disjoint : partition(disjoint, r0, cs),
+                     r1 : region(ispace(int1d), t),
+                     p1_disjoint : partition(disjoint, r1, cs))
 where reads(r0, r1), writes(r0, r1) do
 
   -- not optimized: loop-variant argument is (statically) interfering
@@ -81,20 +88,19 @@ end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
+    r[i].n = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
-  with_partitions(ispace(int1d, n), r0, p0_disjoint, r1, p1_disjoint)
+  with_partitions(cs, r0, p0_disjoint, r1, p1_disjoint)
 end
 regentlib.start(main)
-

--- a/language/tests/regent/compile_fail/optimize_index_launch_list3.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list3.rg
@@ -24,26 +24,30 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
-where reads writes(r) do
+task f(r : region(ispace(int1d), t)) : int
+where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
@@ -51,18 +55,16 @@ end
 task main()
   var n = 5
   var cs = ispace(int1d, n)
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: body is not a single statement
   __demand(__index_launch)

--- a/language/tests/regent/compile_fail/optimize_index_launch_list4.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list4.rg
@@ -24,26 +24,30 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
@@ -51,18 +55,16 @@ end
 task main()
   var n = 5
   var cs = ispace(int1d, n)
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: body is not a bare function call
   __demand(__index_launch)

--- a/language/tests/regent/compile_fail/optimize_index_launch_list5.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list5.rg
@@ -24,26 +24,30 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
@@ -51,18 +55,16 @@ end
 task main()
   var n = 5
   var cs = ispace(int1d, n)
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: function is not a task
   __demand(__index_launch)

--- a/language/tests/regent/compile_fail/optimize_index_launch_list6.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list6.rg
@@ -27,26 +27,30 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
@@ -54,18 +58,16 @@ end
 task main()
   var n = 5
   var cs = ispace(int1d, n)
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var r = region(ispace(int1d, n), t)
+  for i in cs do
+    r[i].f = i
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: argument interferes with itself
   __demand(__index_launch)

--- a/language/tests/regent/compile_fail/optimize_index_launch_list6.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list6.rg
@@ -60,7 +60,7 @@ task main()
   var cs = ispace(int1d, n)
   var r = region(cs, t)
   for i in cs do
-    r[i].f = i
+    r[i].f = i/2
   end
   var p_disjoint = partition(equal, r, cs)
   var p_aliased = image(r, p_disjoint, r.f)

--- a/language/tests/regent/compile_fail/optimize_index_launch_list6.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list6.rg
@@ -58,7 +58,7 @@ end
 task main()
   var n = 5
   var cs = ispace(int1d, n)
-  var r = region(ispace(int1d, n), t)
+  var r = region(cs, t)
   for i in cs do
     r[i].f = i
   end

--- a/language/tests/regent/compile_fail/optimize_index_launch_list6.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list6.rg
@@ -12,6 +12,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
 -- optimize_index_launch_list6.rg:70: loop optimization failed: argument 1 interferes with itself
 --     g(p_disjoint[(int(i) + 1) % n])

--- a/language/tests/regent/compile_fail/optimize_index_launch_list7.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list7.rg
@@ -12,6 +12,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
 -- optimize_index_launch_list7.rg:72: loop optimization failed: argument 1 interferes with itself
 --       g(p_disjoint[(j + 1) % n])

--- a/language/tests/regent/compile_fail/optimize_index_launch_list7.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list7.rg
@@ -27,26 +27,30 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
@@ -54,18 +58,16 @@ end
 task main()
   var n = 5
   var cs = ispace(int1d, n)
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: loop-invariant argument is interfering
   do

--- a/language/tests/regent/compile_fail/optimize_index_launch_list8.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list8.rg
@@ -24,26 +24,30 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
@@ -51,18 +55,16 @@ end
 task main()
   var n = 5
   var cs = ispace(int1d, n)
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: loop-variant argument is interfering
   __demand(__index_launch)

--- a/language/tests/regent/compile_fail/optimize_index_launch_list_vars2.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list_vars2.rg
@@ -12,6 +12,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
 -- optimize_index_launch_list_vars2.rg:34: loop optimization failed: argument 1 interferes with itself
 --     f(p[j])

--- a/language/tests/regent/compile_fail/optimize_index_launch_noninterference1.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_noninterference1.rg
@@ -12,6 +12,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
 -- optimize_index_launch_noninterference1.rg:71: loop optimization failed: argument 1 interferes with itself
 --       g(p_disjoint[(j + 1) % n])

--- a/language/tests/regent/compile_fail/optimize_index_launch_noninterference1.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_noninterference1.rg
@@ -27,44 +27,47 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: loop-invariant argument is interfering
   do

--- a/language/tests/regent/compile_fail/optimize_index_launch_noninterference2.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_noninterference2.rg
@@ -13,7 +13,7 @@
 -- limitations under the License.
 
 -- runs-with:
--- [["-fflow", "0"]]
+-- [["-fflow", "0", "-findex-launch-dynamic", "0"]]
 
 -- fails-with:
 -- optimize_index_launch_noninterference2.rg:83: loop optimization failed: argument 1 interferes with itself

--- a/language/tests/regent/compile_fail/optimize_index_launch_noninterference5.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_noninterference5.rg
@@ -13,7 +13,7 @@
 -- limitations under the License.
 
 -- runs-with:
--- [["-fflow", "0"]]
+-- [["-fflow", "0", "-findex-launch-dynamic", "0"]]
 
 -- fails-with:
 -- optimize_index_launch_noninterference5.rg:84: loop optimization failed: argument 1 interferes with itself

--- a/language/tests/regent/compile_fail/optimize_index_launch_noninterference6.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_noninterference6.rg
@@ -13,7 +13,7 @@
 -- limitations under the License.
 
 -- runs-with:
--- [["-fflow", "0"]]
+-- [["-fflow", "0", "-findex-launch-dynamic", "0"]]
 
 -- fails-with:
 -- optimize_index_launch_noninterference6.rg:84: loop optimization failed: argument 1 interferes with itself

--- a/language/tests/regent/compile_fail/optimize_index_launch_num1.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num1.rg
@@ -24,44 +24,47 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: can't analyze stride
   __demand(__index_launch)

--- a/language/tests/regent/compile_fail/optimize_index_launch_num10.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num10.rg
@@ -24,6 +24,11 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+  n: int,
+}
+
 terra e(x : int) : int
   return 3
 end
@@ -32,43 +37,46 @@ terra e_bad(x : c.legion_runtime_t) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r) do
   return 5
 end
 
-task h(r : region(int)) : int
-where reduces +(r) do
+task h(r : region(ispace(int1d), t)) : int
+where reduces +(r.n) do
   return 5
 end
 
-task h2(r : region(int), s : region(int)) : int
-where reduces +(r, s) do
+task h2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
+where reduces +(r.n, s.n) do
   return 5
 end
 
-task h2b(r : region(int), s : region(int)) : int
-where reduces +(r), reduces *(s) do
+task h2b(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
+where reduces +(r.n), reduces *(s.n) do
   return 5
 end
 
-task with_partitions(r0 : region(int), p0_disjoint : partition(disjoint, r0),
-                     r1 : region(int), p1_disjoint : partition(disjoint, r1),
+task with_partitions(cs : ispace(int1d),
+                     r0 : region(ispace(int1d), t),
+                     p0_disjoint : partition(disjoint, r0, cs),
+                     r1 : region(ispace(int1d), t),
+                     p1_disjoint : partition(disjoint, r1, cs),
                      n : int)
 where reads(r0, r1), writes(r0, r1) do
 
@@ -81,20 +89,19 @@ end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
+    r[i].n = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
-  with_partitions(r0, p0_disjoint, r1, p1_disjoint, n)
+  with_partitions(cs, r0, p0_disjoint, r1, p1_disjoint, n)
 end
 regentlib.start(main)
-

--- a/language/tests/regent/compile_fail/optimize_index_launch_num11.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num11.rg
@@ -24,6 +24,11 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+  n: int,
+}
+
 terra e(x : int) : int
   return 3
 end
@@ -32,43 +37,46 @@ terra e_bad(x : c.legion_runtime_t) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r) do
   return 5
 end
 
-task h(r : region(int)) : int
-where reduces +(r) do
+task h(r : region(ispace(int1d), t)) : int
+where reduces +(r.n) do
   return 5
 end
 
-task h2(r : region(int), s : region(int)) : int
-where reduces +(r, s) do
+task h2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
+where reduces +(r.n, s.n) do
   return 5
 end
 
-task h2b(r : region(int), s : region(int)) : int
-where reduces +(r), reduces *(s) do
+task h2b(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
+where reduces +(r.n), reduces *(s.n) do
   return 5
 end
 
-task with_partitions(r0 : region(int), p0_disjoint : partition(disjoint, r0),
-                     r1 : region(int), p1_disjoint : partition(disjoint, r1),
+task with_partitions(cs : ispace(int1d),
+                     r0 : region(ispace(int1d), t),
+                     p0_disjoint : partition(disjoint, r0, cs),
+                     r1 : region(ispace(int1d), t),
+                     p1_disjoint : partition(disjoint, r1, cs),
                      n : int)
 where reads(r0, r1), writes(r0, r1) do
 
@@ -81,20 +89,19 @@ end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
+    r[i].n = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
-  with_partitions(r0, p0_disjoint, r1, p1_disjoint, n)
+  with_partitions(cs, r0, p0_disjoint, r1, p1_disjoint, n)
 end
 regentlib.start(main)
-

--- a/language/tests/regent/compile_fail/optimize_index_launch_num2.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num2.rg
@@ -24,44 +24,47 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: can't analyze stride
   do

--- a/language/tests/regent/compile_fail/optimize_index_launch_num3.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num3.rg
@@ -24,44 +24,47 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
-where reads writes(r) do
+task f(r : region(ispace(int1d), t)) : int
+where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: body is not a single statement
   __demand(__index_launch)

--- a/language/tests/regent/compile_fail/optimize_index_launch_num4.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num4.rg
@@ -24,44 +24,47 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: body is not a bare function call
   __demand(__index_launch)

--- a/language/tests/regent/compile_fail/optimize_index_launch_num5.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num5.rg
@@ -24,44 +24,47 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: function is not a task
   __demand(__index_launch)

--- a/language/tests/regent/compile_fail/optimize_index_launch_num6.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num6.rg
@@ -27,44 +27,47 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: can't analyze loop-variant argument
   __demand(__index_launch)

--- a/language/tests/regent/compile_fail/optimize_index_launch_num6.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num6.rg
@@ -12,6 +12,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
 -- optimize_index_launch_num6.rg:69: loop optimization failed: argument 1 interferes with itself
 --     g(p_disjoint[(i + 1) % n])

--- a/language/tests/regent/compile_fail/optimize_index_launch_num7.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num7.rg
@@ -27,44 +27,47 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: loop-invariant argument is interfering
   do

--- a/language/tests/regent/compile_fail/optimize_index_launch_num7.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num7.rg
@@ -12,6 +12,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
 -- optimize_index_launch_num7.rg:71: loop optimization failed: argument 1 interferes with itself
 --       g(p_disjoint[(j + 1) % n])

--- a/language/tests/regent/compile_fail/optimize_index_launch_num_affine.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num_affine.rg
@@ -12,6 +12,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
 -- optimize_index_launch_num_affine.rg:39: loop optimization failed: argument 1 interferes with itself
 --     g(p[i * 2 - i - i])

--- a/language/tests/regent/compile_fail/optimize_index_launch_num_vars2.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num_vars2.rg
@@ -12,6 +12,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
 -- optimize_index_launch_num_vars2.rg:33: loop optimization failed: argument 1 interferes with itself
 --     f(p[j])


### PR DESCRIPTION
This PR adds support for emitting a dynamic O(n) check to determine the safety of an index launch when the optimiser is unable to guarantee safety statically.

Edit: Due to a merge conflict, this PR has been moved to #1054 