### PR TITLE
Fix a void* cast in cudart with CUDA11

### DIFF
--- a/runtime/realm/cuda/cudart_hijack.cc
+++ b/runtime/realm/cuda/cudart_hijack.cc
@@ -433,7 +433,7 @@ extern "C" {
 	attr->type = cudaMemoryTypeUnregistered;
 	attr->device = 0;
 	attr->devicePointer = 0;
-	attr->hostPointer = ptr;
+	attr->hostPointer = (void *)ptr;
 	return cudaSuccess;
 #else
 	return cudaErrorInvalidValue;


### PR DESCRIPTION
You run into:legion/runtime/realm/cuda/cudart_hijack.cc:436:22: error:
invalid conversion from ‘const void*’ to ‘void*’ [-fpermissive]
  attr->hostPointer = (const void*) ptr;
                      ^~~~~~~~~~~~~~~~~

TEST: Verify legion builds
Change-Id: Ia15247b728d85860154446b6cffcad1bc868827b