### PR TITLE
Regent: dynamic analysis for index launches (SC21)

### DIFF
--- a/language/src/regent/ast_util.t
+++ b/language/src/regent/ast_util.t
@@ -37,6 +37,16 @@ function ast_util.mk_expr_id(sym, ty)
   }
 end
 
+function ast_util.mk_expr_id_rawref(sym, ty)
+  ty = ty or std.rawref(&sym:gettype())
+  return ast.typed.expr.ID {
+    value = sym,
+    expr_type = ty,
+    span = ast.trivial_span(),
+    annotations = ast.default_annotations(),
+  }
+end
+
 function ast_util.mk_expr_index_access(value, index, ty)
   return ast.typed.expr.IndexAccess {
     value = value,

--- a/language/src/regent/ast_util.t
+++ b/language/src/regent/ast_util.t
@@ -20,6 +20,13 @@ local std = require("regent/std")
 
 local ast_util = {}
 
+function ast_util.mk_stat_break()
+  return ast.typed.stat.Break {
+    span = ast.trivial_span(),
+    annotations = ast.default_annotations()
+  }
+end
+
 function ast_util.mk_expr_id(sym, ty)
   ty = ty or sym:gettype()
   return ast.typed.expr.ID {
@@ -297,6 +304,17 @@ function ast_util.mk_stat_if(cond, stat)
   }
 end
 
+function ast_util.mk_stat_if_else(cond, then_stats, else_stats)
+  return ast.typed.stat.If {
+    cond = cond,
+    then_block = ast_util.mk_block(then_stats),
+    elseif_blocks = terralib.newlist(),
+    else_block = ast_util.mk_block(else_stats),
+    span = ast.trivial_span(),
+    annotations = ast.default_annotations(),
+  }
+end
+
 function ast_util.mk_stat_elseif(cond, stat)
   return ast.typed.stat.Elseif {
     cond = cond,
@@ -335,6 +353,17 @@ function ast_util.mk_stat_for_list(symbol, value, block)
     metadata = false,
     span = ast.trivial_span(),
     annotations = ast.default_annotations(),
+  }
+end
+
+function ast_util.mk_stat_for_num(symbol, values, block)
+  return ast.typed.stat.ForNum {
+    block = block,
+    values = values,
+    symbol = symbol,
+    metadata = false,
+    span = ast.trivial_span(),
+    annotations = ast.default_annotations()
   }
 end
 

--- a/language/src/regent/ast_util.t
+++ b/language/src/regent/ast_util.t
@@ -113,6 +113,16 @@ function ast_util.mk_expr_binary(op, lhs, rhs)
   }
 end
 
+function ast_util.mk_expr_method_call(value, expr_type, method_name, args)
+  return ast.typed.expr.MethodCall {
+    value = value,
+    expr_type = expr_type,
+    method_name = method_name,
+    args = args,
+    span = ast.trivial_span(),
+    annotations = ast.default_annotations()
+  }
+end
 function ast_util.mk_expr_call(fn, args, replicable)
   args = args or terralib.newlist()
   if not terralib.islist(args) then

--- a/language/src/regent/config.t
+++ b/language/src/regent/config.t
@@ -98,6 +98,7 @@ local default_options = {
   ["no-dynamic-branches"] = true,
   ["no-dynamic-branches-assert"] = false,
   ["override-demand-index-launch"] = false,
+  ["index-launch-dynamic"] = true,
   ["override-demand-openmp"] = false,
   ["override-demand-cuda"] = false,
   ["allow-loop-demand-parallel"] = false,

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1218,7 +1218,7 @@ local function init_bitmask(bitmask, volume)
   return util.mk_stat_for_num(idx, values, util.mk_block(stats))
 end
 
--- Computes: pf.z + pf.y * (bounds.hi.z - bounds.lo.z) + pf.x * (bounds.hi.z - bounds.lo.z) * (bounds.hi.y - bounds.lo.y)
+-- Computes: pf.z + pf.y * (bounds.hi.z - bounds.lo.z + 1) + pf.x * (bounds.hi.z - bounds.lo.z + 1) * (bounds.hi.y - bounds.lo.y + 1)
 local function collapse_projection_functor(pf, dim, bounds)
   local index_types = { [0] = std.int1d, std.int1d, std.int2d, std.int3d }
 
@@ -1228,14 +1228,14 @@ local function collapse_projection_functor(pf, dim, bounds)
     local x = util.mk_expr_field_access(pf, "x", int32)
     local y = util.mk_expr_field_access(pf, "y", int32)
   
-    local y_extent = util.mk_expr_binary("-", util.mk_expr_field_access(util.mk_expr_field_access(bounds, "hi", index_types[dim]), "y", int32), util.mk_expr_field_access(util.mk_expr_field_access(bounds, "lo", index_types[dim]), "y", int32))
+    local y_extent = util.mk_expr_binary("+", util.mk_expr_binary("-", util.mk_expr_field_access(util.mk_expr_field_access(bounds, "hi", index_types[dim]), "y", int32), util.mk_expr_field_access(util.mk_expr_field_access(bounds, "lo", index_types[dim]), "y", int32)), util.mk_expr_constant(1, int32))
   
     if dim == 2 then
       return util.mk_expr_binary("+", util.mk_expr_binary("*", x, y_extent), y)
 
     elseif dim == 3 then
       local z = util.mk_expr_field_access(pf, "z", int32)
-      local z_extent = util.mk_expr_binary("-", util.mk_expr_field_access(util.mk_expr_field_access(bounds, "hi", index_types[dim]), "z", int32), util.mk_expr_field_access(util.mk_expr_field_access(bounds, "lo", index_types[dim]), "z", int32))
+      local z_extent = util.mk_expr_binary("+", util.mk_expr_binary("-", util.mk_expr_field_access(util.mk_expr_field_access(bounds, "hi", index_types[dim]), "z", int32), util.mk_expr_field_access(util.mk_expr_field_access(bounds, "lo", index_types[dim]), "z", int32)), util.mk_expr_constant(1, int32))
 
       return util.mk_expr_binary("+", util.mk_expr_binary("*", x, util.mk_expr_binary("*", y_extent, z_extent)), util.mk_expr_binary("+", util.mk_expr_binary("*", y, z_extent), z))
 

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1183,17 +1183,7 @@ local function optimize_loop_body(cx, node, report_pass, report_fail)
   }
 end
 
-function mk_stat_for_num(block, values, sym)
-  return ast.typed.stat.ForNum {
-    block = block,
-    values = values,
-    symbol = sym,
-    metadata = false,
-    span = ast.trivial_span(),
-    annotations = ast.default_annotations()
-  }
-end
-
+-- Initalize bitmask to false
 function init_bitmask(bitmask)
   local stats = terralib.newlist()
 
@@ -1206,25 +1196,26 @@ function init_bitmask(bitmask)
   values:insert(util.mk_expr_constant(0, int32))
   values:insert(util.mk_expr_constant(1e2, int32))
 
-  return mk_stat_for_num(util.mk_block(stats), values, idx)
+  return util.mk_stat_for_num(idx, values, util.mk_block(stats))
 end
 
-function amaze(node)
-  local p_symbol = node.call.args[1].value.value
-  local index_expr = node.call.args[1].index.arg
+function insert_dynamic_check(index_launch_ast, loop_ast)
+  local p_sym = index_launch_ast.call.args[1].value.value
+  local index_expr = index_launch_ast.call.args[1].index.arg
 
+  -- Stats for main loop
   local stats = terralib.newlist()
+
   -- Set colors = 1e2 for now
-  
   local bitmask = std.newsymbol(bool[1e2], "bitmask")
   stats:insert(util.mk_stat_var(bitmask, bool[1e2], false))
   stats:insert(init_bitmask(bitmask))
 
   local value = std.newsymbol(int64, "value")
-  stats:insert(util.mk_stat_var(value, int64, false))
+  stats:insert(util.mk_stat_var(value, int64))
 
   local conflict = std.newsymbol(bool, "conflict")
-  stats:insert(util.mk_stat_var(conflict, bool, util.mk_expr_constant(false, bool)))
+  stats:insert(util.mk_stat_var(conflict, bool, util.mk_expr_constant(false,bool)))
 
   local bounds = terralib.newlist()
   bounds:insert(util.mk_expr_constant(0, int32))
@@ -1233,24 +1224,39 @@ function amaze(node)
   local i = index_expr.lhs.rhs.value -- FIX LATER
 
   local loop = terralib.newlist()
-  loop:insert(util.mk_stat_assignment(util.mk_expr_id(value, std.rawref(&int64)), index_expr))
 
+  -- Computing value = index_expr(i)
+  loop:insert(util.mk_stat_assignment(util.mk_expr_id(value, std.rawref(&value:gettype())), index_expr))
+
+  -- Checks if value < colors
   local cond = util.mk_expr_binary("<", util.mk_expr_id(value), util.mk_expr_constant(100, int32))
   local then_block = terralib.newlist()
 
   local bitmask_value = util.mk_expr_index_access(util.mk_expr_id(bitmask), util.mk_expr_id(value), std.rawref(&bool))
-  local assign = util.mk_stat_assignment(util.mk_expr_id(conflict),  bitmask_value)
-  then_block:insert(assign)
+  local conflict_assign = util.mk_stat_assignment(util.mk_expr_id(conflict, std.rawref(&conflict:gettype())), bitmask_value)
+  then_block:insert(conflict_assign)
+
+  local bitmask_true_assign = util.mk_stat_assignment(bitmask_value, util.mk_expr_constant(true, bool)) 
+  then_block:insert(bitmask_true_assign)
+
+  local check_conflict = util.mk_stat_if(util.mk_expr_id(conflict), util.mk_stat_break())
+  then_block:insert(check_conflict)
 
   local bounds_check = util.mk_stat_if(cond, then_block)
   loop:insert(bounds_check)
 
-  stats:insert(mk_stat_for_num(util.mk_block(loop), bounds, i))
+  stats:insert(util.mk_stat_for_num(i, bounds, util.mk_block(loop)))
+
+  -- Finally checking conflict outside the main loop to decide whether
+  -- to optimize or not
+  local final_check = util.mk_stat_if_else(util.mk_expr_id(conflict), index_launch_ast, loop_ast)
+  stats:insert(final_check)
 
   local block = util.mk_block(stats)
   local stat_block = util.mk_stat_block(block)
   return stat_block
 end
+
 
 function optimize_index_launch.stat_for_num(cx, node)
   local report_pass = ignore
@@ -1284,7 +1290,7 @@ function optimize_index_launch.stat_for_num(cx, node)
     }
   end
 
-  local x = ast.typed.stat.IndexLaunchNum {
+  local index_launch_ast = ast.typed.stat.IndexLaunchNum {
     symbol = node.symbol,
     values = node.values,
     preamble = body.preamble,
@@ -1299,7 +1305,7 @@ function optimize_index_launch.stat_for_num(cx, node)
     annotations = ast.default_annotations(), -- REVERT LATER!
     span = node.span,
   }
-  return amaze(x)
+  return insert_dynamic_check(index_launch_ast, node)
 end
 
 function optimize_index_launch.stat_for_list(cx, node)
@@ -1395,7 +1401,6 @@ function optimize_index_launches.top(cx, node)
 end
 
 function optimize_index_launches.entry(node)
-  --print(node.body.stats)
   local cx = context.new_global_scope({})
   return optimize_index_launches.top(cx, node)
 end

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -25,6 +25,7 @@ local report = require("common/report")
 local std = require("regent/std")
 
 local skip_interference_check = std.config["override-demand-index-launch"]
+local emit_dynamic_check = std.config["index-launch-dynamic"]
 
 local context = {}
 
@@ -1332,7 +1333,7 @@ function optimize_index_launch.stat_for_num(cx, node)
         span = node.span,
     }
 
-    if not body.needs_dynamic_check then
+    if not emit_dynamic_check or not body.needs_dynamic_check then
       return index_launch_ast
     else
       return insert_dynamic_check(index_launch_ast, node {
@@ -1393,7 +1394,7 @@ function optimize_index_launch.stat_for_list(cx, node)
       span = node.span,
     }
 
-    if not body.needs_dynamic_check then
+    if not emit_dynamic_check or not body.needs_dynamic_check then
       return index_launch_ast
     else
       return insert_dynamic_check(index_launch_ast, node {

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -474,6 +474,9 @@ local function analyze_noninterference_self(
     if analyze_index_noninterference_self(index, cx, loop_vars)
     then
       return true
+    else
+      local needs_dynamic_check = true
+      return false, needs_dynamic_check
     end
   end
 
@@ -1144,10 +1147,10 @@ local function optimize_loop_body(cx, node, report_pass, report_fail)
         end
 
         do
-          local passed = analyze_noninterference_self(
+          local passed, needs_dynamic_check = analyze_noninterference_self(
             loop_cx, task, arg, partition_type, mapping, loop_vars)
           if not passed then
-            if emit_dynamic_check then
+            if emit_dynamic_check and needs_dynamic_check then
               report_pass(call, "static loop optimization failed, emitting dynamic check")
               return {
                 preamble = preamble,

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1264,7 +1264,9 @@ local function mk_duplicates_check(preamble, value, index_expr, bitmask, conflic
   then_block:insert(util.mk_stat_if(util.mk_expr_id(conflict), terralib.newlist { set_verdict, util.mk_stat_break() }))
 
   -- Bounds check
-  local cond = util.mk_expr_binary("<", util.mk_expr_id(value), util.mk_expr_id(volume))
+  local cond = util.mk_expr_binary("and",
+    util.mk_expr_binary(">=", util.mk_expr_id(value), util.mk_expr_constant(0, int32)),
+    util.mk_expr_binary("<", util.mk_expr_id(value), util.mk_expr_id(volume)))
   stats:insert(util.mk_stat_if(cond, then_block))
 
   return stats

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1256,13 +1256,11 @@ local function collapse_projection_functor(pf, dim, bounds)
   end
 end
 
-local function insert_dynamic_check(args_need_dynamic_check, index_launch_ast, unopt_loop_ast)
+local function insert_dynamic_check(is_demand, args_need_dynamic_check, index_launch_ast, unopt_loop_ast)
   local check = terralib.newlist()
 
   local index_types = { [0] = std.int1d, std.int1d, std.int2d, std.int3d }
   local rect_types = { [0] = std.rect1d, std.rect1d, std.rect2d, std.rect3d }
-
-  local is_demand = unopt_loop_ast.annotations.index_launch:is(ast.annotation.Demand)
 
   local verdict = std.newsymbol(bool, "verdict")
   check:insert(util.mk_stat_var(verdict, bool, util.mk_expr_constant(false, bool)))
@@ -1371,11 +1369,13 @@ end
 function optimize_index_launch.stat_for_num(cx, node)
   local report_pass = ignore
   local report_fail = report.info
+  local is_demand = false
   if node.annotations.index_launch:is(ast.annotation.Demand) or
     node.annotations.constant_time_launch:is(ast.annotation.Demand)
   then
     report_pass = ignore
     report_fail = report.error
+    is_demand = true
   end
 
   if node.annotations.index_launch:is(ast.annotation.Forbid) then
@@ -1421,7 +1421,7 @@ function optimize_index_launch.stat_for_num(cx, node)
   if #body.args_need_dynamic_check == 0 then
     return index_launch_ast
   else
-    return insert_dynamic_check(body.args_need_dynamic_check, index_launch_ast, node {
+    return insert_dynamic_check(is_demand, body.args_need_dynamic_check, index_launch_ast, node {
       block = optimize_index_launches.block(cx, node.block),
     })
   end
@@ -1430,11 +1430,13 @@ end
 function optimize_index_launch.stat_for_list(cx, node)
   local report_pass = ignore
   local report_fail = report.info
+  local is_demand = false
   if node.annotations.index_launch:is(ast.annotation.Demand) or
     node.annotations.constant_time_launch:is(ast.annotation.Demand)
   then
     report_pass = ignore
     report_fail = report.error
+    is_demand = true
   end
 
   if node.annotations.index_launch:is(ast.annotation.Forbid) then
@@ -1481,7 +1483,7 @@ function optimize_index_launch.stat_for_list(cx, node)
   if #body.args_need_dynamic_check == 0 then
     return index_launch_ast
   else
-    return insert_dynamic_check(body.args_need_dynamic_check, index_launch_ast, node {
+    return insert_dynamic_check(is_demand, body.args_need_dynamic_check, index_launch_ast, node {
       block = optimize_index_launches.block(cx, node.block),
     })
   end

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1213,10 +1213,11 @@ function init_bitmask_false(bitmask)
   return util.mk_stat_for_num(idx, values, util.mk_block(stats))
 end
 
-function get_check_stats(bitmask, value, conflict, index_expr, volume)
+function get_check_stats(preamble, value, index_expr, bitmask, conflict, volume)
   local stats = terralib.newlist()
 
   -- Compute value = index_expr(i)
+  preamble:map(function(stat) stats:insert(stat) end)
   stats:insert(util.mk_stat_assignment(util.mk_expr_id_rawref(value), index_expr))
 
   local then_block = terralib.newlist()
@@ -1272,7 +1273,7 @@ function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
   else
     index_expr = index_launch_ast.call.args[1].index
   end
-  local check_stats = get_check_stats(bitmask, value, conflict, index_expr, volume)
+  local check_stats = get_check_stats(index_launch_ast.preamble, value, index_expr, bitmask, conflict, volume)
 
   local i = index_launch_ast.symbol
   local bounds

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1147,17 +1147,23 @@ local function optimize_loop_body(cx, node, report_pass, report_fail)
           local passed = analyze_noninterference_self(
             loop_cx, task, arg, partition_type, mapping, loop_vars)
           if not passed then
-            report_pass(call, "static loop optimization failed, emitting dynamic check")
-            return {
-              preamble = preamble,
-              call = call,
-              reduce_lhs = reduce_lhs,
-              reduce_op = reduce_op,
-              args_provably = args_provably,
-              free_variables = free_vars,
-              loop_variables = loop_vars,
-              needs_dynamic_check = true
-            }
+            if emit_dynamic_check then
+              report_pass(call, "static loop optimization failed, emitting dynamic check")
+              return {
+                preamble = preamble,
+                call = call,
+                reduce_lhs = reduce_lhs,
+                reduce_op = reduce_op,
+                args_provably = args_provably,
+                free_variables = free_vars,
+                loop_variables = loop_vars,
+                needs_dynamic_check = true
+              }
+            else
+              report_fail(call, "loop optimization failed: argument " .. tostring(i) ..
+                " interferes with itself")
+              return
+            end
           end
         end
       end
@@ -1333,7 +1339,7 @@ function optimize_index_launch.stat_for_num(cx, node)
         span = node.span,
     }
 
-    if not emit_dynamic_check or not body.needs_dynamic_check then
+    if not body.needs_dynamic_check then
       return index_launch_ast
     else
       return insert_dynamic_check(index_launch_ast, node {
@@ -1394,7 +1400,7 @@ function optimize_index_launch.stat_for_list(cx, node)
       span = node.span,
     }
 
-    if not emit_dynamic_check or not body.needs_dynamic_check then
+    if not body.needs_dynamic_check then
       return index_launch_ast
     else
       return insert_dynamic_check(index_launch_ast, node {

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1208,12 +1208,12 @@ end
 local function init_bitmask(bitmask, volume)
   local stats = terralib.newlist()
 
-  local idx = std.newsymbol(int32, "i")
+  local idx = std.newsymbol(int64, "i")
   local bitmask_i = util.mk_expr_index_access(util.mk_expr_id_rawref(bitmask), util.mk_expr_id(idx), std.rawref(&bool))
   stats:insert(util.mk_stat_assignment(bitmask_i, util.mk_expr_constant(false, bool)))
 
   local values = terralib.newlist()
-  values:insert(util.mk_expr_constant(0, int32))
+  values:insert(util.mk_expr_constant(0, int64))
   values:insert(util.mk_expr_id(volume))
 
   return util.mk_stat_for_num(idx, values, util.mk_block(stats))
@@ -1226,25 +1226,25 @@ local function collapse_projection_functor(pf, dim, bounds)
   if dim == 0 or dim == 1 then
     return pf
   else
-    local x = util.mk_expr_field_access(pf, "x", int32)
-    local y = util.mk_expr_field_access(pf, "y", int32)
+    local x = util.mk_expr_field_access(pf, "x", int64)
+    local y = util.mk_expr_field_access(pf, "y", int64)
   
     local y_extent = util.mk_expr_binary("+",
       util.mk_expr_binary("-",
-        util.mk_expr_field_access(util.mk_expr_field_access(bounds, "hi", index_types[dim]), "y", int32),
-        util.mk_expr_field_access(util.mk_expr_field_access(bounds, "lo", index_types[dim]), "y", int32)),
-      util.mk_expr_constant(1, int32))
+        util.mk_expr_field_access(util.mk_expr_field_access(bounds, "hi", index_types[dim]), "y", int64),
+        util.mk_expr_field_access(util.mk_expr_field_access(bounds, "lo", index_types[dim]), "y", int64)),
+      util.mk_expr_constant(1, int64))
   
     if dim == 2 then
       return util.mk_expr_binary("+", util.mk_expr_binary("*", x, y_extent), y)
 
     elseif dim == 3 then
-      local z = util.mk_expr_field_access(pf, "z", int32)
+      local z = util.mk_expr_field_access(pf, "z", int64)
       local z_extent = util.mk_expr_binary("+",
         util.mk_expr_binary("-",
-          util.mk_expr_field_access(util.mk_expr_field_access(bounds, "hi", index_types[dim]), "z", int32),
-          util.mk_expr_field_access(util.mk_expr_field_access(bounds, "lo", index_types[dim]), "z", int32)),
-        util.mk_expr_constant(1, int32))
+          util.mk_expr_field_access(util.mk_expr_field_access(bounds, "hi", index_types[dim]), "z", int64),
+          util.mk_expr_field_access(util.mk_expr_field_access(bounds, "lo", index_types[dim]), "z", int64)),
+        util.mk_expr_constant(1, int64))
 
       return util.mk_expr_binary("+",
         util.mk_expr_binary("*", x, util.mk_expr_binary("*", y_extent, z_extent)),
@@ -1281,13 +1281,13 @@ local function insert_dynamic_check(args_need_dynamic_check, index_launch_ast, u
       -- Generate the AST for var volume = p.colors.bounds:volume()
       local p_colors = util.mk_expr_field_access(util.mk_expr_id(arg.value.value), "colors", std.ispace(index_types[dim]))
       local p_bounds = util.mk_expr_field_access(p_colors, "bounds", rect_types[dim])
-      local volume = std.newsymbol(int32, "volume")
-      stats:insert(util.mk_stat_var(volume, int32, util.mk_expr_method_call(p_bounds, int32, "volume", terralib.newlist())))
+      local volume = std.newsymbol(int64, "volume")
+      stats:insert(util.mk_stat_var(volume, int64, util.mk_expr_method_call(p_bounds, int64, "volume", terralib.newlist())))
   
       -- Malloc a bitmask of size volume and initialize it
       local bitmask_raw = std.newsymbol(&opaque, "bitmask_raw")
       local bitmask = std.newsymbol(&bool, "bitmask")
-      local malloc_call = util.mk_expr_call(std.c.malloc, util.mk_expr_cast(uint64, util.mk_expr_id(volume)))
+      local malloc_call = util.mk_expr_call(std.c.malloc, util.mk_expr_cast(int64, util.mk_expr_id(volume)))
       stats:insert(util.mk_stat_var(bitmask_raw, &opaque, malloc_call))
       stats:insert(util.mk_stat_var(bitmask, &bool, util.mk_expr_cast(&bool, util.mk_expr_id(bitmask_raw))))
       stats:insert(init_bitmask(bitmask, volume))
@@ -1333,7 +1333,7 @@ local function insert_dynamic_check(args_need_dynamic_check, index_launch_ast, u
 
       -- Bounds check
       local cond = util.mk_expr_binary("and",
-        util.mk_expr_binary(">=", util.mk_expr_id(value), util.mk_expr_constant(0, int32)),
+        util.mk_expr_binary(">=", util.mk_expr_id(value), util.mk_expr_constant(0, int64)),
         util.mk_expr_binary("<", util.mk_expr_id(value), util.mk_expr_id(volume)))
       duplicates_check:insert(util.mk_stat_if(cond, then_block))
   

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1146,10 +1146,9 @@ local function optimize_loop_body(cx, node, report_pass, report_fail)
           local passed = analyze_noninterference_self(
             loop_cx, task, arg, partition_type, mapping, loop_vars)
           if not passed then
-            -- Revert later!
-            ignore(call, "loop optimization failed: argument " .. tostring(i) ..
+            ignore(call, "static loop optimization failed: argument " .. tostring(i) ..
                 " interferes with itself")
-            --return
+            return
           end
         end
       end
@@ -1183,12 +1182,12 @@ local function optimize_loop_body(cx, node, report_pass, report_fail)
   }
 end
 
--- Initalize bitmask to false
+-- Initialize bitmask to false
 function init_bitmask(bitmask)
   local stats = terralib.newlist()
 
   local idx = std.newsymbol(int32, "i")
-  local bitmask_i = util.mk_expr_index_access(util.mk_expr_id(bitmask, std.rawref(&bitmask:gettype())), util.mk_expr_id(idx), std.rawref(&bool))
+  local bitmask_i = util.mk_expr_index_access(util.mk_expr_id_rawref(bitmask), util.mk_expr_id(idx), std.rawref(&bool))
   local assign = util.mk_stat_assignment(bitmask_i, util.mk_expr_constant(false, bool))
   stats:insert(assign)
 
@@ -1199,45 +1198,21 @@ function init_bitmask(bitmask)
   return util.mk_stat_for_num(idx, values, util.mk_block(stats))
 end
 
-function insert_dynamic_check(index_launch_ast, loop_ast)
-  local p_sym = index_launch_ast.call.args[1].value.value
-  local index_expr = index_launch_ast.call.args[1].index.arg
-
-  -- Stats for main loop
-  local stats = terralib.newlist()
-
-  -- Set colors = 1e2 for now
-  local bitmask = std.newsymbol(bool[1e2], "bitmask")
-  stats:insert(util.mk_stat_var(bitmask, bool[1e2], false))
-  stats:insert(init_bitmask(bitmask))
-
-  local value = std.newsymbol(int64, "value")
-  stats:insert(util.mk_stat_var(value, int64))
-
-  local conflict = std.newsymbol(bool, "conflict")
-  stats:insert(util.mk_stat_var(conflict, bool, util.mk_expr_constant(false,bool)))
-
-  local bounds = terralib.newlist()
-  bounds:insert(util.mk_expr_constant(0, int32))
-  bounds:insert(util.mk_expr_constant(1e2, int32))
-
-  local i = index_expr.lhs.rhs.value -- FIX LATER
-
+function get_checking_loop_ast(bitmask, value, conflict, index_expr)
   local loop = terralib.newlist()
 
   -- Computing value = index_expr(i)
-  loop:insert(util.mk_stat_assignment(util.mk_expr_id(value, std.rawref(&value:gettype())), index_expr))
+  loop:insert(util.mk_stat_assignment(util.mk_expr_id_rawref(value), index_expr))
 
-  -- Checks if value < colors
   local cond = util.mk_expr_binary("<", util.mk_expr_id(value), util.mk_expr_constant(100, int32))
   local then_block = terralib.newlist()
 
-  local bitmask_value = util.mk_expr_index_access(util.mk_expr_id(bitmask), util.mk_expr_id(value), std.rawref(&bool))
-  local conflict_assign = util.mk_stat_assignment(util.mk_expr_id(conflict, std.rawref(&conflict:gettype())), bitmask_value)
+  local bitmask_at_value = util.mk_expr_index_access(util.mk_expr_id(bitmask), util.mk_expr_id(value), std.rawref(&bool))
+  local conflict_assign = util.mk_stat_assignment(util.mk_expr_id_rawref(conflict), bitmask_at_value)
   then_block:insert(conflict_assign)
 
-  local bitmask_true_assign = util.mk_stat_assignment(bitmask_value, util.mk_expr_constant(true, bool)) 
-  then_block:insert(bitmask_true_assign)
+  local bitmask_assign_true = util.mk_stat_assignment(bitmask_at_value, util.mk_expr_constant(true, bool)) 
+  then_block:insert(bitmask_assign_true)
 
   local check_conflict = util.mk_stat_if(util.mk_expr_id(conflict), util.mk_stat_break())
   then_block:insert(check_conflict)
@@ -1245,18 +1220,43 @@ function insert_dynamic_check(index_launch_ast, loop_ast)
   local bounds_check = util.mk_stat_if(cond, then_block)
   loop:insert(bounds_check)
 
-  stats:insert(util.mk_stat_for_num(i, bounds, util.mk_block(loop)))
+  return loop
+end
 
-  -- Finally checking conflict outside the main loop to decide whether
+function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
+  local p_sym = index_launch_ast.call.args[1].value.value
+  local index_expr = index_launch_ast.call.args[1].index.arg
+  local i = index_launch_ast.symbol
+
+  local main_stats = terralib.newlist()
+
+  -- Set colors = 1e2 for now
+  local bitmask = std.newsymbol(bool[1e2], "bitmask")
+  main_stats:insert(util.mk_stat_var(bitmask, bool[1e2], false))
+  main_stats:insert(init_bitmask(bitmask))
+
+  local value = std.newsymbol(int64, "value")
+  main_stats:insert(util.mk_stat_var(value, int64))
+
+  local conflict = std.newsymbol(bool, "conflict")
+  main_stats:insert(util.mk_stat_var(conflict, bool, util.mk_expr_constant(false, bool)))
+
+  local bounds = terralib.newlist()
+  bounds:insert(util.mk_expr_constant(0, int32))
+  bounds:insert(util.mk_expr_constant(1e2, int32))
+
+  local loop = get_checking_loop_ast(bitmask, value, conflict, index_expr)
+  main_stats:insert(util.mk_stat_for_num(i, bounds, util.mk_block(loop)))
+
+  -- Finally checking conflict outside the loop to decide whether
   -- to optimize or not
-  local final_check = util.mk_stat_if_else(util.mk_expr_id(conflict), index_launch_ast, loop_ast)
-  stats:insert(final_check)
+  local final_check = util.mk_stat_if_else(util.mk_expr_id(conflict), unoptimized_loop_ast, index_launch_ast)
+  main_stats:insert(final_check)
 
-  local block = util.mk_block(stats)
+  local block = util.mk_block(main_stats)
   local stat_block = util.mk_stat_block(block)
   return stat_block
 end
-
 
 function optimize_index_launch.stat_for_num(cx, node)
   local report_pass = ignore
@@ -1283,11 +1283,10 @@ function optimize_index_launch.stat_for_num(cx, node)
     return node
   end
 
+  local needs_dynamic_check = false
   local body = optimize_loop_body(cx, node, report_pass, report_fail)
   if not body then
-    return node {
-      block = optimize_index_launches.block(cx, node.block),
-    }
+    needs_dynamic_check = true
   end
 
   local index_launch_ast = ast.typed.stat.IndexLaunchNum {
@@ -1302,10 +1301,17 @@ function optimize_index_launch.stat_for_num(cx, node)
     is_constant_time = body.is_constant_time,
     free_vars = body.free_variables,
     loop_vars = body.loop_variables,
-    annotations = ast.default_annotations(), -- REVERT LATER!
+    annotations = node.annotations,
     span = node.span,
   }
-  return insert_dynamic_check(index_launch_ast, node)
+
+  if needs_dynamic_check then
+    return insert_dynamic_check(index_launch_ast, node {
+      block = optimize_index_launches.block(cx, node.block)
+      })
+  else
+    return index_launch_ast
+  end
 end
 
 function optimize_index_launch.stat_for_list(cx, node)
@@ -1334,14 +1340,13 @@ function optimize_index_launch.stat_for_list(cx, node)
     return node
   end
 
+  local needs_dynamic_check = false
   local body = optimize_loop_body(cx, node, report_pass, report_fail)
   if not body then
-    return node {
-      block = optimize_index_launches.block(cx, node.block),
-    }
+    needs_dynamic_check = true
   end
 
-  return ast.typed.stat.IndexLaunchList {
+  local index_launch_ast = ast.typed.stat.IndexLaunchList {
     symbol = node.symbol,
     value = node.value,
     preamble = body.preamble,
@@ -1356,6 +1361,14 @@ function optimize_index_launch.stat_for_list(cx, node)
     annotations = node.annotations,
     span = node.span,
   }
+
+  if needs_dynamic_check then
+    return insert_dynamic_check(index_launch_ast, node {
+      block = optimize_index_launches.block(cx, node.block)
+      })
+  else
+    return index_launch_ast
+  end
 end
 
 local function do_nothing(cx, node) return node end

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -479,9 +479,6 @@ local function analyze_noninterference_self(
     if analyze_index_noninterference_self(index, cx, loop_vars)
     then
       return true, false
-    else
-      local needs_dynamic_check = true
-      return false, needs_dynamic_check
     end
   end
 
@@ -500,10 +497,11 @@ local function analyze_noninterference_self(
         coherence == "simultaneous" or
         #field_paths == 0)
     then
-      return false
+       -- The only case where we emit the dynamic check
+       return false, true
     end
   end
-  return true
+  return true, false
 end
 
 local function always_true(cx, node)

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1227,9 +1227,8 @@ local function get_check_stats(preamble, value, index_expr, bitmask, conflict, v
   local bitmask_assign_true = util.mk_stat_assignment(bitmask_value, util.mk_expr_constant(true, bool)) 
   then_block:insert(bitmask_assign_true)
 
-  local save_pos = util.mk_stat_assignment(util.mk_expr_id_rawref(pos), util.mk_expr_id(loop_var))
   local set_verdict = util.mk_stat_assignment(util.mk_expr_id_rawref(verdict), util.mk_expr_constant(true, bool))
-  local check_conflict = util.mk_stat_if(util.mk_expr_id(conflict), terralib.newlist { save_pos, set_verdict, util.mk_stat_break() })
+  local check_conflict = util.mk_stat_if(util.mk_expr_id(conflict), terralib.newlist { set_verdict, util.mk_stat_break() })
   then_block:insert(check_conflict)
 
   local cond = util.mk_expr_binary("<", util.mk_expr_id(value), util.mk_expr_id(volume))

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1328,6 +1328,8 @@ local function insert_dynamic_check(args_need_dynamic_check, index_launch_ast, u
         bounds = index_launch_ast.value
         stats:insert(util.mk_stat_for_list(i, bounds, util.mk_block(duplicates_check)))
       end
+
+      stats:insert(util.mk_stat_expr(util.mk_expr_call(std.c.free, util.mk_expr_id(bitmask))))
     end
   end
 
@@ -1337,7 +1339,7 @@ local function insert_dynamic_check(args_need_dynamic_check, index_launch_ast, u
       util.mk_expr_constant(false, bool), util.mk_expr_constant(get_source_location(unopt_loop_ast) ..
         ": loop ineligible for index launch due to non-injective projection functor", rawstring)
       }))
-    stats:insert(util.mk_stat_if_else(util.mk_expr_id(verdict), util.mk_stat_block(util.mk_block(abort)), index_launch_ast))
+    stats:insert(util.mk_stat_if_else(util.mk_expr_id(verdict), abort, index_launch_ast))
   else
     stats:insert(util.mk_stat_if_else(util.mk_expr_id(verdict), unopt_loop_ast, index_launch_ast))
   end

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -473,7 +473,8 @@ end
 local function analyze_noninterference_self(
     cx, task, arg, partition_type, mapping, loop_vars)
   local region_type = std.as_read(arg.expr_type)
-  if partition_type and partition_type:is_disjoint() then
+  local is_disjoint = partition_type and partition_type:is_disjoint()
+  if is_disjoint then
     local index =
       (arg:is(ast.typed.expr.Projection) and arg.region.index) or arg.index
     if analyze_index_noninterference_self(index, cx, loop_vars)
@@ -497,8 +498,12 @@ local function analyze_noninterference_self(
         coherence == "simultaneous" or
         #field_paths == 0)
     then
-       -- The only case where we emit the dynamic check
-       return false, true
+       if not is_disjoint then
+         return false, false
+       else
+         -- The only case where we emit the dynamic check
+         return false, true
+       end
     end
   end
   return true, false

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1215,12 +1215,39 @@ local function init_bitmask(bitmask, volume)
   return util.mk_stat_for_num(idx, values, util.mk_block(stats))
 end
 
-local function mk_duplicates_check(preamble, value, index_expr, bitmask, conflict, verdict, loop_var, volume)
+-- Computes: pf.z + pf.y * (bounds.hi.z - bounds.lo.z) + pf.x * (bounds.hi.z - bounds.lo.z) * (bounds.hi.y - bounds.lo.y)
+local function collapse_projection_functor(pf, dim, bounds)
+  local index_types = { std.int1d, std.int2d, std.int3d }
+
+  if dim == 1 then
+    return pf
+  else
+    local x = util.mk_expr_field_access(pf, "x", int32)
+    local y = util.mk_expr_field_access(pf, "y", int32)
+  
+    local y_extent = util.mk_expr_binary("-", util.mk_expr_field_access(util.mk_expr_field_access(bounds, "hi", index_types[dim]), "y", int32), util.mk_expr_field_access(util.mk_expr_field_access(bounds, "lo", index_types[dim]), "y", int32))
+  
+    if dim == 2 then
+      return util.mk_expr_binary("+", util.mk_expr_binary("*", x, y_extent), y)
+
+    elseif dim == 3 then
+      local z = util.mk_expr_field_access(pf, "z", int32)
+      local z_extent = util.mk_expr_binary("-", util.mk_expr_field_access(util.mk_expr_field_access(bounds, "hi", index_types[dim]), "z", int32), util.mk_expr_field_access(util.mk_expr_field_access(bounds, "lo", index_types[dim]), "z", int32))
+
+      return util.mk_expr_binary("+", util.mk_expr_binary("*", x, util.mk_expr_binary("*", y_extent, z_extent)), util.mk_expr_binary("+", util.mk_expr_binary("*", y, z_extent), z))
+
+    else
+      assert(false)
+    end
+  end
+end
+
+local function mk_duplicates_check(preamble, value, index_expr, bitmask, conflict, verdict, loop_var, bounds, dim, volume)
   local stats = terralib.newlist()
 
   -- Compute value = index_expr(i)
   preamble:map(function(stat) stats:insert(stat) end)
-  stats:insert(util.mk_stat_assignment(util.mk_expr_id_rawref(value), index_expr))
+  stats:insert(util.mk_stat_assignment(util.mk_expr_id_rawref(value), collapse_projection_functor(index_expr, dim, bounds)))
 
   local then_block = terralib.newlist()
 
@@ -1241,7 +1268,6 @@ end
 
 local function insert_dynamic_check(index_launch_ast, unopt_loop_ast)
   local stats = terralib.newlist()
-  --stats:insert(util.mk_block(util.mk_stat_expr(util.mk_expr_call(std.assert_error, terralib.newlist { util.mk_expr_constant(false, bool), util.mk_expr_constant("F", rawstring) }))))
 
   local verdict = std.newsymbol(bool, "verdict")
   stats:insert(util.mk_stat_var(verdict, bool, util.mk_expr_constant(false, bool)))
@@ -1250,12 +1276,15 @@ local function insert_dynamic_check(index_launch_ast, unopt_loop_ast)
     -- Skip non-partition args
     if arg:is(ast.typed.expr.IndexAccess) and
        std.is_region(arg.expr_type) and
-       std.is_partition(std.as_read(arg.value.expr_type)) and
-       (arg.expr_type:ispace().dim == 1) then
+       std.is_partition(std.as_read(arg.value.expr_type)) then
+
+      local dim = arg.expr_type:ispace().dim
+      local index_types = { std.int1d, std.int2d, std.int3d }
+      local rect_types = { std.rect1d, std.rect2d, std.rect3d }
 
       -- Generate the AST for var volume = p.colors.bounds:volume()
-      local p_colors = util.mk_expr_field_access(util.mk_expr_id(arg.value.value), "colors", std.ispace(std.int1d))
-      local p_bounds = util.mk_expr_field_access(p_colors, "bounds", std.rect1d)
+      local p_colors = util.mk_expr_field_access(util.mk_expr_id(arg.value.value), "colors", std.ispace(index_types[dim]))
+      local p_bounds = util.mk_expr_field_access(p_colors, "bounds", rect_types[dim])
       local p_volume = util.mk_expr_method_call(p_bounds, int32, "volume", terralib.newlist())
       local volume = std.newsymbol(int32, "volume")
       stats:insert(util.mk_stat_var(volume, int32, p_volume))
@@ -1283,7 +1312,7 @@ local function insert_dynamic_check(index_launch_ast, unopt_loop_ast)
       end
   
       local i = index_launch_ast.symbol
-      local duplicates_check = mk_duplicates_check(index_launch_ast.preamble, value, index_expr, bitmask, conflict, verdict, i, volume)
+      local duplicates_check = mk_duplicates_check(index_launch_ast.preamble, value, index_expr, bitmask, conflict, verdict, i, p_bounds, dim, volume)
   
       local bounds
       -- Generate the AST based on loop type

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1382,19 +1382,19 @@ function optimize_index_launch.stat_for_num(cx, node)
   -- If we reach here then either the self interference test failed,
   -- or the optimization was successful.
   local index_launch_ast = ast.typed.stat.IndexLaunchNum {
-      symbol = node.symbol,
-      values = node.values,
-      preamble = body.preamble,
-      call = body.call,
-      reduce_lhs = body.reduce_lhs,
-      reduce_op = body.reduce_op,
-      reduce_task = false,
-      args_provably = body.args_provably,
-      is_constant_time = body.is_constant_time,
-      free_vars = body.free_variables,
-      loop_vars = body.loop_variables,
-      annotations = node.annotations,
-      span = node.span,
+    symbol = node.symbol,
+    values = node.values,
+    preamble = body.preamble,
+    call = body.call,
+    reduce_lhs = body.reduce_lhs,
+    reduce_op = body.reduce_op,
+    reduce_task = false,
+    args_provably = body.args_provably,
+    is_constant_time = body.is_constant_time,
+    free_vars = body.free_variables,
+    loop_vars = body.loop_variables,
+    annotations = node.annotations,
+    span = node.span,
   }
 
   if #body.args_need_dynamic_check == 0 then

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1191,8 +1191,7 @@ local function optimize_loop_body(cx, node, report_pass, report_fail)
   }
 end
 
--- Initialize bitmask to false
-function init_bitmask(bitmask)
+function init_bitmask_false(bitmask)
   local stats = terralib.newlist()
 
   local idx = std.newsymbol(int32, "i")
@@ -1207,62 +1206,72 @@ function init_bitmask(bitmask)
   return util.mk_stat_for_num(idx, values, util.mk_block(stats))
 end
 
-function get_checking_loop_ast(bitmask, value, conflict, index_expr)
-  local loop = terralib.newlist()
+function get_check_stats(bitmask, value, conflict, index_expr, volume)
+  local stats = terralib.newlist()
 
-  -- Computing value = index_expr(i)
-  loop:insert(util.mk_stat_assignment(util.mk_expr_id_rawref(value), index_expr))
+  -- Compute value = index_expr(i)
+  stats:insert(util.mk_stat_assignment(util.mk_expr_id_rawref(value), index_expr))
 
-  local cond = util.mk_expr_binary("<", util.mk_expr_id(value), util.mk_expr_constant(100, int32))
+  local cond = util.mk_expr_binary("<", util.mk_expr_id(value), util.mk_expr_id(volume))
   local then_block = terralib.newlist()
 
-  local bitmask_at_value = util.mk_expr_index_access(util.mk_expr_id(bitmask), util.mk_expr_id(value), std.rawref(&bool))
-  local conflict_assign = util.mk_stat_assignment(util.mk_expr_id_rawref(conflict), bitmask_at_value)
+  local bitmask_value = util.mk_expr_index_access(util.mk_expr_id(bitmask), util.mk_expr_id(value), std.rawref(&bool))
+  local conflict_assign = util.mk_stat_assignment(util.mk_expr_id_rawref(conflict), bitmask_value)
   then_block:insert(conflict_assign)
 
-  local bitmask_assign_true = util.mk_stat_assignment(bitmask_at_value, util.mk_expr_constant(true, bool)) 
+  local bitmask_assign_true = util.mk_stat_assignment(bitmask_value, util.mk_expr_constant(true, bool)) 
   then_block:insert(bitmask_assign_true)
 
   local check_conflict = util.mk_stat_if(util.mk_expr_id(conflict), util.mk_stat_break())
   then_block:insert(check_conflict)
 
   local bounds_check = util.mk_stat_if(cond, then_block)
-  loop:insert(bounds_check)
+  stats:insert(bounds_check)
 
-  return loop
+  return stats
 end
 
 function insert_dynamic_check(index_launch_ast, unoptimized_loop_ast)
-  local p_sym = index_launch_ast.call.args[1].value.value
-  local index_expr = index_launch_ast.call.args[1].index.arg
-  local i = index_launch_ast.symbol
+  local stats = terralib.newlist()
 
-  local main_stats = terralib.newlist()
+  -- Generating the AST for var volume = p.colors.bounds:volume()
+  local p_symbol = index_launch_ast.call.args[1].value.value
+  local p_colors = util.mk_expr_field_access(util.mk_expr_id(p_symbol), "colors", std.ispace(std.int1d))
+  local p_bounds = util.mk_expr_field_access(p_colors, "bounds", std.rect1d)
+  local p_volume = util.mk_expr_method_call(p_bounds, int32, "volume", terralib.newlist())
+  local volume = std.newsymbol(int32, "volume")
+  stats:insert(util.mk_stat_var(volume, nil, p_volume))
 
   -- Set colors = 1e2 for now
   local bitmask = std.newsymbol(bool[1e2], "bitmask")
-  main_stats:insert(util.mk_stat_var(bitmask, bool[1e2], false))
-  main_stats:insert(init_bitmask(bitmask))
+  stats:insert(util.mk_stat_var(bitmask, bool[1e2], false))
+  stats:insert(init_bitmask_false(bitmask))
 
   local value = std.newsymbol(int64, "value")
-  main_stats:insert(util.mk_stat_var(value, int64))
+  stats:insert(util.mk_stat_var(value, int64))
 
   local conflict = std.newsymbol(bool, "conflict")
-  main_stats:insert(util.mk_stat_var(conflict, bool, util.mk_expr_constant(false, bool)))
+  stats:insert(util.mk_stat_var(conflict, bool, util.mk_expr_constant(false, bool)))
 
-  local bounds = terralib.newlist()
-  bounds:insert(util.mk_expr_constant(0, int32))
-  bounds:insert(util.mk_expr_constant(1e2, int32))
+  local index_expr = index_launch_ast.call.args[1].index.arg
+  local check_stats = get_check_stats(bitmask, value, conflict, index_expr, volume)
 
-  local loop = get_checking_loop_ast(bitmask, value, conflict, index_expr)
-  main_stats:insert(util.mk_stat_for_num(i, bounds, util.mk_block(loop)))
+  local i = index_launch_ast.symbol
+  local bounds
+  -- Figure out what type of loop we've got and generate its AST
+  if unoptimized_loop_ast.node_type:is(ast.typed.stat.ForNum) then
+    bounds = index_launch_ast.values
+    stats:insert(util.mk_stat_for_num(i, bounds, util.mk_block(check_stats)))
+  else
+    bounds = index_launch_ast.value
+    stats:insert(util.mk_stat_for_list(i, bounds, util.mk_block(check_stats)))
+  end
 
-  -- Finally checking conflict outside the loop to decide whether
-  -- to optimize or not
+  -- Finally check conflict outside the loop to decide whether to optimize or not
   local final_check = util.mk_stat_if_else(util.mk_expr_id(conflict), unoptimized_loop_ast, index_launch_ast)
-  main_stats:insert(final_check)
+  stats:insert(final_check)
 
-  local block = util.mk_block(main_stats)
+  local block = util.mk_block(stats)
   local stat_block = util.mk_stat_block(block)
   return stat_block
 end
@@ -1353,7 +1362,6 @@ function optimize_index_launch.stat_for_list(cx, node)
     return node
   end
 
-  local needs_dynamic_check = false
   local body = optimize_loop_body(cx, node, report_pass, report_fail)
   if not body then
     return node {

--- a/language/tests/regent/compile_fail/optimize_index_launch_list10.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list10.rg
@@ -13,9 +13,9 @@
 -- limitations under the License.
 
 -- fails-with:
--- optimize_index_launch_list10.rg:78: loop optimization failed: argument 2 interferes with argument 1
+-- optimize_index_launch_list10.rg:85: loop optimization failed: argument 2 interferes with argument 1
 --     g2(p0_disjoint[i], p1_disjoint[i])
---      ^
+--       ^
 
 import "regent"
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_list11.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list11.rg
@@ -24,6 +24,11 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+  n: int,
+}
+
 terra e(x : int) : int
   return 3
 end
@@ -32,44 +37,46 @@ terra e_bad(x : c.legion_runtime_t) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r) do
   return 5
 end
 
-task h(r : region(int)) : int
-where reduces +(r) do
+task h(r : region(ispace(int1d), t)) : int
+where reduces +(r.n) do
   return 5
 end
 
-task h2(r : region(int), s : region(int)) : int
-where reduces +(r, s) do
+task h2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
+where reduces +(r.n, s.n) do
   return 5
 end
 
-task h2b(r : region(int), s : region(int)) : int
-where reduces +(r), reduces *(s) do
+task h2b(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
+where reduces +(r.n), reduces *(s.n) do
   return 5
 end
 
 task with_partitions(cs : ispace(int1d),
-                     r0 : region(int), p0_disjoint : partition(disjoint, r0),
-                     r1 : region(int), p1_disjoint : partition(disjoint, r1))
+                     r0 : region(ispace(int1d), t),
+                     p0_disjoint : partition(disjoint, r0, cs),
+                     r1 : region(ispace(int1d), t),
+                     p1_disjoint : partition(disjoint, r1, cs))
 where reads(r0, r1), writes(r0, r1) do
 
   -- not optimized: loop-variant argument is (statically) interfering
@@ -81,20 +88,19 @@ end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
+    r[i].n = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
-  with_partitions(ispace(int1d, n), r0, p0_disjoint, r1, p1_disjoint)
+  with_partitions(cs, r0, p0_disjoint, r1, p1_disjoint)
 end
 regentlib.start(main)
-

--- a/language/tests/regent/compile_fail/optimize_index_launch_list11.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list11.rg
@@ -13,9 +13,9 @@
 -- limitations under the License.
 
 -- fails-with:
--- optimize_index_launch_list11.rg:78: loop optimization failed: argument 2 interferes with argument 1
+-- optimize_index_launch_list11.rg:85: loop optimization failed: argument 2 interferes with argument 1
 --     h2b(p0_disjoint[i], p1_disjoint[i])
---       ^
+--        ^
 
 import "regent"
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_list3.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list3.rg
@@ -13,9 +13,9 @@
 -- limitations under the License.
 
 -- fails-with:
--- optimize_index_launch_list3.rg:70: loop optimization failed: preamble statement is not a variable
+-- optimize_index_launch_list3.rg:73: loop optimization failed: preamble statement is not a variable
 --     f(p_disjoint[i])
---     ^
+--      ^
 
 import "regent"
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_list3.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list3.rg
@@ -24,26 +24,30 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
-where reads writes(r) do
+task f(r : region(ispace(int1d), t)) : int
+where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
@@ -51,18 +55,16 @@ end
 task main()
   var n = 5
   var cs = ispace(int1d, n)
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: body is not a single statement
   __demand(__index_launch)

--- a/language/tests/regent/compile_fail/optimize_index_launch_list4.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list4.rg
@@ -13,7 +13,7 @@
 -- limitations under the License.
 
 -- fails-with:
--- optimize_index_launch_list4.rg:70: loop optimization failed: body is not a function call
+-- optimize_index_launch_list4.rg:72: loop optimization failed: body is not a function call
 --     var x = f(p_disjoint[i])
 --       ^
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_list4.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list4.rg
@@ -24,26 +24,30 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
@@ -51,18 +55,16 @@ end
 task main()
   var n = 5
   var cs = ispace(int1d, n)
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: body is not a bare function call
   __demand(__index_launch)

--- a/language/tests/regent/compile_fail/optimize_index_launch_list5.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list5.rg
@@ -24,26 +24,30 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
@@ -51,18 +55,16 @@ end
 task main()
   var n = 5
   var cs = ispace(int1d, n)
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: function is not a task
   __demand(__index_launch)

--- a/language/tests/regent/compile_fail/optimize_index_launch_list5.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list5.rg
@@ -13,9 +13,9 @@
 -- limitations under the License.
 
 -- fails-with:
--- optimize_index_launch_list5.rg:70: loop optimization failed: function is not a task
+-- optimize_index_launch_list5.rg:72: loop optimization failed: function is not a task
 --     e(i)
---     ^
+--      ^
 
 import "regent"
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_list6.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list6.rg
@@ -16,9 +16,9 @@
 -- [["-findex-launch-dynamic", "0"]]
 
 -- fails-with:
--- optimize_index_launch_list6.rg:70: loop optimization failed: argument 1 interferes with itself
+-- optimize_index_launch_list6.rg:75: loop optimization failed: argument 1 interferes with itself
 --     g(p_disjoint[(int(i) + 1) % n])
---     ^
+--      ^
 
 import "regent"
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_list6.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list6.rg
@@ -27,26 +27,30 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
@@ -54,18 +58,16 @@ end
 task main()
   var n = 5
   var cs = ispace(int1d, n)
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var r = region(ispace(int1d, n), t)
+  for i in cs do
+    r[i].f = i
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: argument interferes with itself
   __demand(__index_launch)

--- a/language/tests/regent/compile_fail/optimize_index_launch_list6.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list6.rg
@@ -60,7 +60,7 @@ task main()
   var cs = ispace(int1d, n)
   var r = region(cs, t)
   for i in cs do
-    r[i].f = i
+    r[i].f = i/2
   end
   var p_disjoint = partition(equal, r, cs)
   var p_aliased = image(r, p_disjoint, r.f)

--- a/language/tests/regent/compile_fail/optimize_index_launch_list6.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list6.rg
@@ -58,7 +58,7 @@ end
 task main()
   var n = 5
   var cs = ispace(int1d, n)
-  var r = region(ispace(int1d, n), t)
+  var r = region(cs, t)
   for i in cs do
     r[i].f = i
   end

--- a/language/tests/regent/compile_fail/optimize_index_launch_list6.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list6.rg
@@ -12,6 +12,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
 -- optimize_index_launch_list6.rg:70: loop optimization failed: argument 1 interferes with itself
 --     g(p_disjoint[(int(i) + 1) % n])

--- a/language/tests/regent/compile_fail/optimize_index_launch_list7.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list7.rg
@@ -12,6 +12,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
 -- optimize_index_launch_list7.rg:72: loop optimization failed: argument 1 interferes with itself
 --       g(p_disjoint[(j + 1) % n])

--- a/language/tests/regent/compile_fail/optimize_index_launch_list7.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list7.rg
@@ -27,26 +27,30 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
@@ -54,18 +58,16 @@ end
 task main()
   var n = 5
   var cs = ispace(int1d, n)
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: loop-invariant argument is interfering
   do

--- a/language/tests/regent/compile_fail/optimize_index_launch_list7.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list7.rg
@@ -16,9 +16,9 @@
 -- [["-findex-launch-dynamic", "0"]]
 
 -- fails-with:
--- optimize_index_launch_list7.rg:72: loop optimization failed: argument 1 interferes with itself
+-- optimize_index_launch_list7.rg:77: loop optimization failed: argument 1 interferes with itself
 --       g(p_disjoint[(j + 1) % n])
---       ^
+--        ^
 
 import "regent"
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_list8.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list8.rg
@@ -13,9 +13,9 @@
 -- limitations under the License.
 
 -- fails-with:
--- optimize_index_launch_list8.rg:70: loop optimization failed: argument 1 interferes with itself
+-- optimize_index_launch_list8.rg:72: loop optimization failed: argument 1 interferes with itself
 --     g(p_aliased[i])
---     ^
+--      ^
 
 import "regent"
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_list8.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list8.rg
@@ -24,26 +24,30 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
@@ -51,18 +55,16 @@ end
 task main()
   var n = 5
   var cs = ispace(int1d, n)
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: loop-variant argument is interfering
   __demand(__index_launch)

--- a/language/tests/regent/compile_fail/optimize_index_launch_list_vars2.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list_vars2.rg
@@ -16,7 +16,7 @@
 -- [["-findex-launch-dynamic", "0"]]
 
 -- fails-with:
--- optimize_index_launch_list_vars2.rg:34: loop optimization failed: argument 1 interferes with itself
+-- optimize_index_launch_list_vars2.rg:37: loop optimization failed: argument 1 interferes with itself
 --     f(p[j])
 --      ^
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_list_vars2.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list_vars2.rg
@@ -12,6 +12,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
 -- optimize_index_launch_list_vars2.rg:34: loop optimization failed: argument 1 interferes with itself
 --     f(p[j])

--- a/language/tests/regent/compile_fail/optimize_index_launch_noninjective.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_noninjective.rg
@@ -13,7 +13,7 @@
 -- limitations under the License.
 
 -- fails-with:
--- optimize_index_launch_noninjective.rg:29: loop ineligible for index launch due to non-injective projection functor
+-- optimize_index_launch_noninjective.rg:29: loop optimization failed: argument 1 interferes with itself
 
 import "regent"
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_noninjective.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_noninjective.rg
@@ -13,7 +13,7 @@
 -- limitations under the License.
 
 -- fails-with:
--- optimize_index_launch_noninjective.rg:30: loop ineligible for index launch due to non-injective projection functor
+-- optimize_index_launch_noninjective.rg:29: loop ineligible for index launch due to non-injective projection functor
 
 import "regent"
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_noninjective.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_noninjective.rg
@@ -1,0 +1,34 @@
+-- Copyright 2021 Stanford University
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- fails-with:
+-- Errors reported during runtime.
+-- optimize_index_launch_noninjective.rg:30: loop ineligible for index launch due to non-injective projection functor
+
+import "regent"
+
+task foo(r : region(ispace(int1d), int))
+where reads writes(r) do 
+end
+
+task main()
+  var r = region(ispace(int1d, 10), int)
+  var p = partition(equal, r, ispace(int1d, 5))
+
+  __demand(__index_launch)
+  for i in ispace(int1d, 5) do
+    foo(p[i%2])
+  end
+end
+regentlib.start(main)

--- a/language/tests/regent/compile_fail/optimize_index_launch_noninjective.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_noninjective.rg
@@ -13,7 +13,6 @@
 -- limitations under the License.
 
 -- fails-with:
--- Errors reported during runtime.
 -- optimize_index_launch_noninjective.rg:30: loop ineligible for index launch due to non-injective projection functor
 
 import "regent"

--- a/language/tests/regent/compile_fail/optimize_index_launch_noninterference1.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_noninterference1.rg
@@ -12,6 +12,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
 -- optimize_index_launch_noninterference1.rg:71: loop optimization failed: argument 1 interferes with itself
 --       g(p_disjoint[(j + 1) % n])

--- a/language/tests/regent/compile_fail/optimize_index_launch_noninterference1.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_noninterference1.rg
@@ -27,44 +27,47 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: loop-invariant argument is interfering
   do

--- a/language/tests/regent/compile_fail/optimize_index_launch_noninterference1.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_noninterference1.rg
@@ -16,9 +16,9 @@
 -- [["-findex-launch-dynamic", "0"]]
 
 -- fails-with:
--- optimize_index_launch_noninterference1.rg:71: loop optimization failed: argument 1 interferes with itself
+-- optimize_index_launch_noninterference1.rg:77: loop optimization failed: argument 1 interferes with itself
 --       g(p_disjoint[(j + 1) % n])
---       ^
+--        ^
 
 import "regent"
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_noninterference2.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_noninterference2.rg
@@ -13,7 +13,7 @@
 -- limitations under the License.
 
 -- runs-with:
--- [["-fflow", "0"]]
+-- [["-fflow", "0", "-findex-launch-dynamic", "0"]]
 
 -- fails-with:
 -- optimize_index_launch_noninterference2.rg:83: loop optimization failed: argument 1 interferes with itself

--- a/language/tests/regent/compile_fail/optimize_index_launch_noninterference3.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_noninterference3.rg
@@ -13,7 +13,7 @@
 -- limitations under the License.
 
 -- runs-with:
--- [["-fflow", "0"]]
+-- [["-fflow", "0", "-findex-launch-dynamic", "0"]]
 
 -- fails-with:
 -- optimize_index_launch_noninterference3.rg:84: loop optimization failed: argument 1 interferes with itself

--- a/language/tests/regent/compile_fail/optimize_index_launch_noninterference4.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_noninterference4.rg
@@ -13,7 +13,7 @@
 -- limitations under the License.
 
 -- runs-with:
--- [["-fflow", "0"]]
+-- [["-fflow", "0", "-findex-launch-dynamic", "0"]]
 
 -- fails-with:
 -- optimize_index_launch_noninterference4.rg:84: loop optimization failed: argument 1 interferes with itself

--- a/language/tests/regent/compile_fail/optimize_index_launch_noninterference5.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_noninterference5.rg
@@ -13,7 +13,7 @@
 -- limitations under the License.
 
 -- runs-with:
--- [["-fflow", "0"]]
+-- [["-fflow", "0", "-findex-launch-dynamic", "0"]]
 
 -- fails-with:
 -- optimize_index_launch_noninterference5.rg:84: loop optimization failed: argument 1 interferes with itself

--- a/language/tests/regent/compile_fail/optimize_index_launch_noninterference6.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_noninterference6.rg
@@ -13,7 +13,7 @@
 -- limitations under the License.
 
 -- runs-with:
--- [["-fflow", "0"]]
+-- [["-fflow", "0", "-findex-launch-dynamic", "0"]]
 
 -- fails-with:
 -- optimize_index_launch_noninterference6.rg:84: loop optimization failed: argument 1 interferes with itself

--- a/language/tests/regent/compile_fail/optimize_index_launch_num1.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num1.rg
@@ -13,9 +13,9 @@
 -- limitations under the License.
 
 -- fails-with:
--- optimize_index_launch_num1.rg:68: loop optimization failed: stride not equal to 1
+-- optimize_index_launch_num1.rg:71: loop optimization failed: stride not equal to 1
 --   for i = 0, n, 2 do
---                 ^
+--     ^
 
 import "regent"
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_num1.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num1.rg
@@ -24,44 +24,47 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: can't analyze stride
   __demand(__index_launch)

--- a/language/tests/regent/compile_fail/optimize_index_launch_num10.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num10.rg
@@ -24,6 +24,11 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+  n: int,
+}
+
 terra e(x : int) : int
   return 3
 end
@@ -32,43 +37,46 @@ terra e_bad(x : c.legion_runtime_t) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r) do
   return 5
 end
 
-task h(r : region(int)) : int
-where reduces +(r) do
+task h(r : region(ispace(int1d), t)) : int
+where reduces +(r.n) do
   return 5
 end
 
-task h2(r : region(int), s : region(int)) : int
-where reduces +(r, s) do
+task h2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
+where reduces +(r.n, s.n) do
   return 5
 end
 
-task h2b(r : region(int), s : region(int)) : int
-where reduces +(r), reduces *(s) do
+task h2b(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
+where reduces +(r.n), reduces *(s.n) do
   return 5
 end
 
-task with_partitions(r0 : region(int), p0_disjoint : partition(disjoint, r0),
-                     r1 : region(int), p1_disjoint : partition(disjoint, r1),
+task with_partitions(cs : ispace(int1d),
+                     r0 : region(ispace(int1d), t),
+                     p0_disjoint : partition(disjoint, r0, cs),
+                     r1 : region(ispace(int1d), t),
+                     p1_disjoint : partition(disjoint, r1, cs),
                      n : int)
 where reads(r0, r1), writes(r0, r1) do
 
@@ -81,20 +89,19 @@ end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
+    r[i].n = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
-  with_partitions(r0, p0_disjoint, r1, p1_disjoint, n)
+  with_partitions(cs, r0, p0_disjoint, r1, p1_disjoint, n)
 end
 regentlib.start(main)
-

--- a/language/tests/regent/compile_fail/optimize_index_launch_num10.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num10.rg
@@ -13,9 +13,9 @@
 -- limitations under the License.
 
 -- fails-with:
--- optimize_index_launch_num10.rg:78: loop optimization failed: argument 2 interferes with argument 1
+-- optimize_index_launch_num10.rg:86: loop optimization failed: argument 2 interferes with argument 1
 --     g2(p0_disjoint[i], p1_disjoint[i])
---      ^
+--       ^
 
 import "regent"
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_num11.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num11.rg
@@ -13,9 +13,9 @@
 -- limitations under the License.
 
 -- fails-with:
--- optimize_index_launch_num11.rg:78: loop optimization failed: argument 2 interferes with argument 1
+-- optimize_index_launch_num11.rg:86: loop optimization failed: argument 2 interferes with argument 1
 --     h2b(p0_disjoint[i], p1_disjoint[i])
---       ^
+--        ^
 
 import "regent"
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_num11.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num11.rg
@@ -24,6 +24,11 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+  n: int,
+}
+
 terra e(x : int) : int
   return 3
 end
@@ -32,43 +37,46 @@ terra e_bad(x : c.legion_runtime_t) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r) do
   return 5
 end
 
-task h(r : region(int)) : int
-where reduces +(r) do
+task h(r : region(ispace(int1d), t)) : int
+where reduces +(r.n) do
   return 5
 end
 
-task h2(r : region(int), s : region(int)) : int
-where reduces +(r, s) do
+task h2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
+where reduces +(r.n, s.n) do
   return 5
 end
 
-task h2b(r : region(int), s : region(int)) : int
-where reduces +(r), reduces *(s) do
+task h2b(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
+where reduces +(r.n), reduces *(s.n) do
   return 5
 end
 
-task with_partitions(r0 : region(int), p0_disjoint : partition(disjoint, r0),
-                     r1 : region(int), p1_disjoint : partition(disjoint, r1),
+task with_partitions(cs : ispace(int1d),
+                     r0 : region(ispace(int1d), t),
+                     p0_disjoint : partition(disjoint, r0, cs),
+                     r1 : region(ispace(int1d), t),
+                     p1_disjoint : partition(disjoint, r1, cs),
                      n : int)
 where reads(r0, r1), writes(r0, r1) do
 
@@ -81,20 +89,19 @@ end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
+    r[i].n = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
-  with_partitions(r0, p0_disjoint, r1, p1_disjoint, n)
+  with_partitions(cs, r0, p0_disjoint, r1, p1_disjoint, n)
 end
 regentlib.start(main)
-

--- a/language/tests/regent/compile_fail/optimize_index_launch_num2.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num2.rg
@@ -13,9 +13,9 @@
 -- limitations under the License.
 
 -- fails-with:
--- optimize_index_launch_num2.rg:70: loop optimization failed: stride not equal to 1
+-- optimize_index_launch_num2.rg:73: loop optimization failed: stride not equal to 1
 --     for i = 0, n, s do
---                   ^
+--       ^
 
 import "regent"
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_num2.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num2.rg
@@ -24,44 +24,47 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: can't analyze stride
   do

--- a/language/tests/regent/compile_fail/optimize_index_launch_num3.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num3.rg
@@ -13,9 +13,9 @@
 -- limitations under the License.
 
 -- fails-with:
--- optimize_index_launch_num3.rg:69: loop optimization failed: preamble statement is not a variable
+-- optimize_index_launch_num3.rg:73: loop optimization failed: preamble statement is not a variable
 --     f(p_disjoint[i])
---     ^
+--      ^
 
 import "regent"
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_num3.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num3.rg
@@ -24,44 +24,47 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
-where reads writes(r) do
+task f(r : region(ispace(int1d), t)) : int
+where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: body is not a single statement
   __demand(__index_launch)

--- a/language/tests/regent/compile_fail/optimize_index_launch_num4.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num4.rg
@@ -13,7 +13,7 @@
 -- limitations under the License.
 
 -- fails-with:
--- optimize_index_launch_num4.rg:69: loop optimization failed: body is not a function call
+-- optimize_index_launch_num4.rg:72: loop optimization failed: body is not a function call
 --     var x = f(p_disjoint[i])
 --       ^
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_num4.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num4.rg
@@ -24,44 +24,47 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: body is not a bare function call
   __demand(__index_launch)

--- a/language/tests/regent/compile_fail/optimize_index_launch_num5.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num5.rg
@@ -24,44 +24,47 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: function is not a task
   __demand(__index_launch)

--- a/language/tests/regent/compile_fail/optimize_index_launch_num5.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num5.rg
@@ -13,9 +13,9 @@
 -- limitations under the License.
 
 -- fails-with:
--- optimize_index_launch_num5.rg:69: loop optimization failed: function is not a task
+-- optimize_index_launch_num5.rg:72: loop optimization failed: function is not a task
 --     e(i)
---     ^
+--      ^
 
 import "regent"
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_num6.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num6.rg
@@ -16,9 +16,9 @@
 -- [["-findex-launch-dynamic", "0"]]
 
 -- fails-with:
--- optimize_index_launch_num6.rg:69: loop optimization failed: argument 1 interferes with itself
+-- optimize_index_launch_num6.rg:75: loop optimization failed: argument 1 interferes with itself
 --     g(p_disjoint[(i + 1) % n])
---     ^
+--      ^
 
 import "regent"
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_num6.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num6.rg
@@ -27,44 +27,47 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: can't analyze loop-variant argument
   __demand(__index_launch)

--- a/language/tests/regent/compile_fail/optimize_index_launch_num6.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num6.rg
@@ -12,6 +12,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
 -- optimize_index_launch_num6.rg:69: loop optimization failed: argument 1 interferes with itself
 --     g(p_disjoint[(i + 1) % n])

--- a/language/tests/regent/compile_fail/optimize_index_launch_num7.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num7.rg
@@ -16,9 +16,9 @@
 -- [["-findex-launch-dynamic", "0"]]
 
 -- fails-with:
--- optimize_index_launch_num7.rg:71: loop optimization failed: argument 1 interferes with itself
+-- optimize_index_launch_num7.rg:77: loop optimization failed: argument 1 interferes with itself
 --       g(p_disjoint[(j + 1) % n])
---       ^
+--        ^
 
 import "regent"
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_num7.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num7.rg
@@ -27,44 +27,47 @@ import "regent"
 
 local c = regentlib.c
 
+struct t {
+  f: int1d,
+}
+
 terra e(x : int) : int
   return 3
 end
 
-task f(r : region(int)) : int
+task f(r : region(ispace(int1d), t)) : int
 where reads(r) do
   return 5
 end
 
-task f2(r : region(int), s : region(int)) : int
+task f2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s) do
   return 5
 end
 
-task g(r : region(int)) : int
+task g(r : region(ispace(int1d), t)) : int
 where reads(r), writes(r) do
   return 5
 end
 
-task g2(r : region(int), s : region(int)) : int
+task g2(r : region(ispace(int1d), t), s : region(ispace(int1d), t)) : int
 where reads(r, s), writes(r, s) do
   return 5
 end
 
 task main()
   var n = 5
-  var r = region(ispace(ptr, n), int)
-  var rc = c.legion_coloring_create()
-  for i = 0, n do
-    c.legion_coloring_ensure_color(rc, i)
+  var cs = ispace(int1d, n)
+  var r = region(cs, t)
+  for i in cs do
+    r[i].f = i/2
   end
-  var p_disjoint = partition(disjoint, r, rc)
-  var p_aliased = partition(aliased, r, rc)
+  var p_disjoint = partition(equal, r, cs)
+  var p_aliased = image(r, p_disjoint, r.f)
   var r0 = p_disjoint[0]
   var r1 = p_disjoint[1]
-  var p0_disjoint = partition(disjoint, r0, rc)
-  var p1_disjoint = partition(disjoint, r1, rc)
-  c.legion_coloring_destroy(rc)
+  var p0_disjoint = partition(equal, r0, cs)
+  var p1_disjoint = partition(equal, r1, cs)
 
   -- not optimized: loop-invariant argument is interfering
   do

--- a/language/tests/regent/compile_fail/optimize_index_launch_num7.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num7.rg
@@ -12,6 +12,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
 -- optimize_index_launch_num7.rg:71: loop optimization failed: argument 1 interferes with itself
 --       g(p_disjoint[(j + 1) % n])

--- a/language/tests/regent/compile_fail/optimize_index_launch_num8.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num8.rg
@@ -13,9 +13,9 @@
 -- limitations under the License.
 
 -- fails-with:
--- optimize_index_launch_num8.rg:69: loop optimization failed: argument 1 interferes with itself
+-- optimize_index_launch_num8.rg:72: loop optimization failed: argument 1 interferes with itself
 --     g(p_aliased[i])
---     ^
+--      ^
 
 import "regent"
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_num_affine.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num_affine.rg
@@ -12,6 +12,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
 -- optimize_index_launch_num_affine.rg:39: loop optimization failed: argument 1 interferes with itself
 --     g(p[i * 2 - i - i])

--- a/language/tests/regent/compile_fail/optimize_index_launch_num_affine.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num_affine.rg
@@ -16,7 +16,7 @@
 -- [["-findex-launch-dynamic", "0"]]
 
 -- fails-with:
--- optimize_index_launch_num_affine.rg:39: loop optimization failed: argument 1 interferes with itself
+-- optimize_index_launch_num_affine.rg:42: loop optimization failed: argument 1 interferes with itself
 --     g(p[i * 2 - i - i])
 --      ^
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_num_vars2.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num_vars2.rg
@@ -16,7 +16,7 @@
 -- [["-findex-launch-dynamic", "0"]]
 
 -- fails-with:
--- optimize_index_launch_num_vars2.rg:33: loop optimization failed: argument 1 interferes with itself
+-- optimize_index_launch_num_vars2.rg:36: loop optimization failed: argument 1 interferes with itself
 --     f(p[j])
 --      ^
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_num_vars2.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num_vars2.rg
@@ -12,6 +12,9 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
 -- optimize_index_launch_num_vars2.rg:33: loop optimization failed: argument 1 interferes with itself
 --     f(p[j])

--- a/language/tests/regent/run_pass/optimize_index_launch_dom_3d.rg
+++ b/language/tests/regent/run_pass/optimize_index_launch_dom_3d.rg
@@ -1,0 +1,48 @@
+-- Copyright 2021 Stanford University
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+import "regent"
+
+task sweep(r_points : region(ispace(int3d), int),
+           r_x_faces : region(ispace(int2d), int),
+           r_y_faces : region(ispace(int2d), int),
+           r_z_faces : region(ispace(int2d), int))
+where reads writes(r_points, r_x_faces, r_y_faces, r_z_faces) do
+end
+
+task f(d : int, nx : int, ny : int, nz : int)
+  -- this is degenerate and doesn't actually do anything interesting,
+  -- but is sufficient for the static check
+  return ispace(int3d, {1, 1, 1}, {d, d, d})
+end
+
+task main()
+  var r_points = region(ispace(int3d, {10, 10, 10}), int)
+  var r_x_faces = region(ispace(int2d, {10, 10}), int)
+  var r_y_faces = region(ispace(int2d, {10, 10}), int)
+  var r_z_faces = region(ispace(int2d, {10, 10}), int)
+
+  var p_points = partition(equal, r_points, ispace(int3d, {4, 4, 4}))
+  var p_x_faces = partition(equal, r_x_faces, ispace(int2d, {4, 4}))
+  var p_y_faces = partition(equal, r_y_faces, ispace(int2d, {4, 4}))
+  var p_z_faces = partition(equal, r_z_faces, ispace(int2d, {4, 4}))
+
+  for d = 0, 4 do
+     __demand(__index_launch)
+    for c in f(d, 4, 4, 4) do -- f maps diagonals to subsets of NX x NY
+      sweep(p_points[c], p_x_faces[{c.y, c.z}], p_y_faces[{c.x, c.z}], p_z_faces[{c.x, c.y}])
+    end
+  end
+end
+regentlib.start(main)


### PR DESCRIPTION
This PR adds support for a large class of index launches in the compiler, via dynamic analysis.

This code is triggered if the static analyzer fails to analyze a projection functor. It will then emit an O(N) dynamic check that is sound and complete for determining if the projection functor is injective over the launch domain. The index launch will be executed based on the result of check.

The bulk of the implementation is as an AST transformation during the index launch optimization pass.

Finally, there are several updates to Regent tests, including removing usage of the old partition API in many places.