### PR TITLE
Regent: dynamic projection functor cross-checks

### DIFF
--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1302,7 +1302,7 @@ local function collect_and_sort_args(args, call_args, task, param_region_types)
   for _, args in pairs(array) do
     table.sort(args, function(p, q)
       local p_privileges, _, _, _, _ = std.find_task_privileges(param_region_types[p], task)
-      if p_privileges[1] == "reads_writes" then
+      if p_privileges[1] == "reads_writes" or string.find(p_privileges[1], "reduces") then
         return true
       end
       return false

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -244,7 +244,7 @@ local function analyze_noninterference_previous(
   if region_type:is_projected() then
     region_type = region_type:get_projection_source()
   end
-  local args_interfering = {}
+  local args_interfering = terralib.newlist()
   for i, other_arg in pairs(regions_previously_used) do
     local other_region_type = std.as_read(other_arg.expr_type)
     if other_region_type:is_projected() then
@@ -263,7 +263,7 @@ local function analyze_noninterference_previous(
         -- Index non-interference is handled at the type checker level
         -- and is captured in the constraints.
     then
-      table.insert(args_interfering, i)
+      args_interfering:insert(i)
     end
   end
 

--- a/language/src/regent/optimize_index_launches.t
+++ b/language/src/regent/optimize_index_launches.t
@@ -1276,29 +1276,30 @@ end
 
 local function collect_and_sort_args(args, call_args, task, param_region_types)
   local collected = {}
-
-  for _, idx in pairs(args) do
-    if type(idx) == "number" then
-      collected[call_args[idx].value.value] = collected[call_args[idx].value.value] or {}
-      collected[call_args[idx].value.value][idx] = true
+  for _, arg in pairs(args) do
+    if type(arg) == "number" then
+      local pname = call_args[arg].value.value
+      collected[pname] = collected[pname] or {}
+      collected[pname][arg] = true
     else
       -- Cross-check args are pairs
-      collected[call_args[idx[1]].value.value] = collected[call_args[idx[1]].value.value] or {}
-      collected[call_args[idx[1]].value.value][idx[1]] = true
-      collected[call_args[idx[1]].value.value][idx[2]] = true
+      local pname = call_args[arg[1]].value.value
+      collected[pname] = collected[pname] or {}
+      collected[pname][arg[1]] = true
+      collected[pname][arg[2]] = true
     end
   end
 
   local array = {}
-  for k, v in pairs(collected) do
-    array[k] = {}
-    for kk, vv in pairs(v) do
-      if vv then table.insert(array[k], kk) end
+  for pname, args in pairs(collected) do
+    array[pname] = {}
+    for arg, v in pairs(args) do
+      if v then table.insert(array[pname], arg) end
     end 
   end
 
-  for k, v in pairs(array) do
-    table.sort(v, function(p, q)
+  for _, args in pairs(array) do
+    table.sort(args, function(p, q)
       local p_privileges, _, _, _, _ = std.find_task_privileges(param_region_types[p], task)
       if p_privileges[1] == "reads_writes" then
         return true
@@ -1315,7 +1316,7 @@ local c = terralib.includecstring([[
 #include <stdlib.h>
 ]])
 
-terra assert_dyn_check_error(x : bool, message : rawstring, arg1 : uint8, arg2: uint8)
+terra assert_dynamic_check_error(x : bool, message : rawstring, arg1 : uint8, arg2: uint8)
   if not x then
     var stderr = c.fdopen(2, "w")
     if arg1 == arg2 then
@@ -1345,7 +1346,8 @@ local function insert_dynamic_check(is_demand, args_need_dynamic_check, index_la
   local verdict = std.newsymbol(bool, "verdict")
   check:insert(util.mk_stat_var(verdict, bool, util.mk_expr_constant(false, bool)))
 
-  local collected_args = collect_and_sort_args(args_need_dynamic_check, call_args, task, param_region_types)
+  local collected_args = collect_and_sort_args(
+    args_need_dynamic_check, call_args, task, param_region_types)
 
   for _, args in pairs(collected_args) do
     local stats = terralib.newlist()
@@ -1353,17 +1355,24 @@ local function insert_dynamic_check(is_demand, args_need_dynamic_check, index_la
     local dim = call_args[args[1]].expr_type:ispace().dim
 
     -- Generate the AST for var volume = p.colors.bounds:volume()
-    local p_colors = util.mk_expr_field_access(util.mk_expr_id(call_args[args[1]].value.value), "colors", std.ispace(index_types[dim]))
+    local p_colors = util.mk_expr_field_access(
+      util.mk_expr_id(call_args[args[1]].value.value), "colors", std.ispace(index_types[dim]))
     local p_bounds = util.mk_expr_field_access(p_colors, "bounds", rect_types[dim])
     local volume = std.newsymbol(int64, "volume")
-    stats:insert(util.mk_stat_var(volume, int64, util.mk_expr_method_call(p_bounds, int64, "volume", terralib.newlist())))
+    stats:insert(
+     util.mk_stat_var(volume, int64, util.mk_expr_method_call(
+       p_bounds, int64, "volume", terralib.newlist())))
 
     -- Malloc a bitmask of size volume and initialize it
     local bitmask_raw = std.newsymbol(&opaque, "bitmask_raw")
     local bitmask = std.newsymbol(&uint8, "bitmask")
-    local malloc_call = util.mk_expr_call(std.c.malloc, util.mk_expr_cast(int64, util.mk_expr_id(volume)))
-    stats:insert(util.mk_stat_var(bitmask_raw, &opaque, malloc_call))
-    stats:insert(util.mk_stat_var(bitmask, &uint8, util.mk_expr_cast(&uint8, util.mk_expr_id(bitmask_raw))))
+    local malloc_call = util.mk_expr_call(
+      std.c.malloc,
+      util.mk_expr_cast(int64, util.mk_expr_id(volume)))
+    stats:insert(
+      util.mk_stat_var(bitmask_raw, &opaque, malloc_call))
+    stats:insert(
+      util.mk_stat_var(bitmask, &uint8, util.mk_expr_cast(&uint8, util.mk_expr_id(bitmask_raw))))
     stats:insert(init_bitmask(bitmask, volume))
 
     local value = std.newsymbol(int64, "value")
@@ -1376,73 +1385,75 @@ local function insert_dynamic_check(is_demand, args_need_dynamic_check, index_la
       local duplicates_check = terralib.newlist()
       index_launch_ast.preamble:map(function(stat) duplicates_check:insert(stat) end)
   
-      local mk_duplicates_check = function(index_expr, error_msg, duplicate_stats)
-        if unopt_loop_ast.node_type:is(ast.typed.stat.ForNum) then
-          index_expr = index_expr.arg
-        end
-  
-        -- Assign: value = collapse(index_expr)
-        duplicate_stats:insert(
-          util.mk_stat_assignment(
-            util.mk_expr_id_rawref(value),
-            collapse_projection_functor(index_expr, dim, p_bounds)))
-  
-        local then_block = terralib.newlist()
-  
-        local bitmask_value = util.mk_expr_index_access(util.mk_expr_id(bitmask),
-          util.mk_expr_id(value), std.rawref(&uint8))
-        then_block:insert(util.mk_stat_assignment(util.mk_expr_id_rawref(conflict), bitmask_value))
-  
-        local privileges, _, _, _, _ = std.find_task_privileges(param_region_types[arg], task)
-        assert(#privileges == 1)
-        if privileges[1] ~= "reads" then
-          then_block:insert(util.mk_stat_assignment(bitmask_value, util.mk_expr_constant(arg, uint8)))
-        end
-  
-        -- Issue an error here if we have to
-        if is_demand then
-          local abort = util.mk_stat_expr(util.mk_expr_call(assert_dyn_check_error, terralib.newlist {
-            util.mk_expr_constant(false, bool),
-            util.mk_expr_constant(get_source_location(unopt_loop_ast) .. error_msg, rawstring),
-            util.mk_expr_constant(arg, uint8),
-            util.mk_expr_id(conflict)
-            }))
-          then_block:insert(
-            util.mk_stat_if(
-              util.mk_expr_binary("~=",
-                util.mk_expr_id(conflict),
-                util.mk_expr_constant(0, uint8)),
-              terralib.newlist { abort }))
-        else
-          local set_verdict = util.mk_stat_assignment(util.mk_expr_id_rawref(verdict),
-            util.mk_expr_constant(true, bool))
-          then_block:insert(
-            util.mk_stat_if(
-              util.mk_expr_binary("~=",
-                util.mk_expr_id(conflict),
-                util.mk_expr_constant(0, uint8)),
-              terralib.newlist { set_verdict, util.mk_stat_break() }))
-        end
-  
-        -- Bounds check
-        local cond = util.mk_expr_binary("and",
-          util.mk_expr_binary(">=", util.mk_expr_id(value), util.mk_expr_constant(0, int64)),
-          util.mk_expr_binary("<", util.mk_expr_id(value), util.mk_expr_id(volume)))
-        duplicate_stats:insert(util.mk_stat_if(cond, then_block))
+      local index_expr
+      if unopt_loop_ast.node_type:is(ast.typed.stat.ForNum) then
+        index_expr = call_args[arg].index.arg
+      else
+        index_expr = call_args[arg].index
       end
-  
-      mk_duplicates_check(call_args[arg].index,
-        " loop optimization failed: argument ",
-        duplicates_check)
 
+      -- Assign: value = collapse(index_expr)
+      duplicates_check:insert(
+        util.mk_stat_assignment(
+          util.mk_expr_id_rawref(value),
+          collapse_projection_functor(index_expr, dim, p_bounds)))
+
+      local then_block = terralib.newlist()
+
+      local bitmask_value = util.mk_expr_index_access(util.mk_expr_id(bitmask),
+        util.mk_expr_id(value), std.rawref(&uint8))
+      then_block:insert(util.mk_stat_assignment(util.mk_expr_id_rawref(conflict), bitmask_value))
+
+      local privileges, _, _, _, _ = std.find_task_privileges(param_region_types[arg], task)
+      assert(#privileges == 1)
+      if privileges[1] ~= "reads" then
+        then_block:insert(util.mk_stat_assignment(bitmask_value, util.mk_expr_constant(arg, uint8)))
+      end
+
+      -- Issue an error here if we have to
+      if is_demand then
+        local abort = util.mk_stat_expr(util.mk_expr_call(assert_dynamic_check_error, terralib.newlist {
+          util.mk_expr_constant(false, bool),
+          util.mk_expr_constant(
+            get_source_location(unopt_loop_ast) ..
+            ": loop optimization failed: argument ",
+            rawstring),
+          util.mk_expr_constant(arg, uint8),
+          util.mk_expr_id(conflict)
+          }))
+        then_block:insert(
+          util.mk_stat_if(
+            util.mk_expr_binary("~=",
+              util.mk_expr_id(conflict),
+              util.mk_expr_constant(0, uint8)),
+            terralib.newlist { abort }))
+      else
+        local set_verdict = util.mk_stat_assignment(util.mk_expr_id_rawref(verdict),
+          util.mk_expr_constant(true, bool))
+        then_block:insert(
+          util.mk_stat_if(
+            util.mk_expr_binary("~=",
+              util.mk_expr_id(conflict),
+              util.mk_expr_constant(0, uint8)),
+            terralib.newlist { set_verdict, util.mk_stat_break() }))
+      end
+
+      -- Bounds check
+      local cond = util.mk_expr_binary("and",
+        util.mk_expr_binary(">=", util.mk_expr_id(value), util.mk_expr_constant(0, int64)),
+        util.mk_expr_binary("<", util.mk_expr_id(value), util.mk_expr_id(volume)))
+      duplicates_check:insert(util.mk_stat_if(cond, then_block))
+  
       local bounds
       -- Generate the AST based on loop type
       if unopt_loop_ast.node_type:is(ast.typed.stat.ForNum) then
         bounds = index_launch_ast.values
-        stats:insert(util.mk_stat_for_num(index_launch_ast.symbol, bounds, util.mk_block(duplicates_check)))
+        stats:insert(
+          util.mk_stat_for_num(index_launch_ast.symbol, bounds, util.mk_block(duplicates_check)))
       else
         bounds = index_launch_ast.value
-        stats:insert(util.mk_stat_for_list(index_launch_ast.symbol, bounds, util.mk_block(duplicates_check)))
+        stats:insert(
+          util.mk_stat_for_list(index_launch_ast.symbol, bounds, util.mk_block(duplicates_check)))
       end
     end -- for loop over args
 
@@ -1454,7 +1465,7 @@ local function insert_dynamic_check(is_demand, args_need_dynamic_check, index_la
       -- Skip this check if a previous one failed
       check:insert(util.mk_stat_if_else(util.mk_expr_id(verdict), terralib.newlist(), stats))
     end
-   end -- for loop over collected_args
+  end -- for loop over collected_args
 
   -- In the demand case we know it's safe to optimize here, otherwise we need to check verdict
   if is_demand then

--- a/language/src/regent/std.t
+++ b/language/src/regent/std.t
@@ -4710,6 +4710,12 @@ local function generate_task_interfaces(task_whitelist)
     for _, definition in ipairs(definitions) do
       task_impl[definition[1]] = definition[2]
     end
+    -- In separate compilation, need to make sure all globals get exported.
+    if base.config["separate"] then
+      task_impl[task:get_task_id().name] = task:get_task_id()
+      task_impl[task:get_mapper_id().name] = task:get_mapper_id()
+      task_impl[task:get_mapping_tag_id().name] = task:get_mapping_tag_id()
+    end
   end
 
   return task_c_iface:concat("\n\n"), task_cxx_iface:concat("\n\n"), task_impl

--- a/language/tests/regent/compile_fail/optimize_index_launch_list10.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list10.rg
@@ -12,8 +12,11 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
--- optimize_index_launch_list10.rg:85: loop optimization failed: argument 2 interferes with argument 1
+-- optimize_index_launch_list10.rg:88: loop optimization failed: argument 2 interferes with argument 1
 --     g2(p0_disjoint[i], p1_disjoint[i])
 --       ^
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_list11.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_list11.rg
@@ -12,8 +12,11 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
--- optimize_index_launch_list11.rg:85: loop optimization failed: argument 2 interferes with argument 1
+-- optimize_index_launch_list11.rg:88: loop optimization failed: argument 2 interferes with argument 1
 --     h2b(p0_disjoint[i], p1_disjoint[i])
 --        ^
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_noninterference_cross.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_noninterference_cross.rg
@@ -13,12 +13,13 @@
 -- limitations under the License.
 
 -- fails-with:
--- optimize_index_launch_noninterference_cross.rg:29: loop optimization failed: argument 2 interferes with argument 1
+-- optimize_index_launch_noninterference_cross.rg:30: loop optimization failed: argument 2 interferes with argument 1
+--        ^
 
 import "regent"
 
 task foo(r: region(ispace(int1d), int), s: region(ispace(int1d), int), t: region(ispace(int1d), int))
-where reads writes(r, s), reads (t) do
+where reads writes(r), reads (s, t) do
 end
 
 task main()
@@ -27,7 +28,7 @@ task main()
 
   __demand(__index_launch)
   for i in ispace(int1d, 5) do
-    foo(p[i/1], p[i], p[i%2])
+    foo(p[i], p[i/1], p[i/2])
   end
 end
 regentlib.start(main)

--- a/language/tests/regent/compile_fail/optimize_index_launch_noninterference_cross.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_noninterference_cross.rg
@@ -1,0 +1,33 @@
+-- Copyright 2021 Stanford University
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- fails-with:
+-- optimize_index_launch_noninterference_cross.rg:29: loop optimization failed: argument 2 interferes with argument 1
+
+import "regent"
+
+task foo(r: region(ispace(int1d), int), s: region(ispace(int1d), int), t: region(ispace(int1d), int))
+where reads writes(r, s), reads (t) do
+end
+
+task main()
+  var r = region(ispace(int1d, 10), int)
+  var p = partition(equal, r, ispace(int1d, 5))
+
+  __demand(__index_launch)
+  for i in ispace(int1d, 5) do
+    foo(p[i/1], p[i], p[i%2])
+  end
+end
+regentlib.start(main)

--- a/language/tests/regent/compile_fail/optimize_index_launch_noninterference_cross.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_noninterference_cross.rg
@@ -13,8 +13,7 @@
 -- limitations under the License.
 
 -- fails-with:
--- optimize_index_launch_noninterference_cross.rg:30: loop optimization failed: argument 2 interferes with argument 1
---        ^
+-- optimize_index_launch_noninterference_cross.rg:29: loop optimization failed: argument 2 interferes with argument 1
 
 import "regent"
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_num10.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num10.rg
@@ -12,8 +12,11 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
--- optimize_index_launch_num10.rg:86: loop optimization failed: argument 2 interferes with argument 1
+-- optimize_index_launch_num10.rg:89: loop optimization failed: argument 2 interferes with argument 1
 --     g2(p0_disjoint[i], p1_disjoint[i])
 --       ^
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_num11.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num11.rg
@@ -12,8 +12,11 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
--- optimize_index_launch_num11.rg:86: loop optimization failed: argument 2 interferes with argument 1
+-- optimize_index_launch_num11.rg:89: loop optimization failed: argument 2 interferes with argument 1
 --     h2b(p0_disjoint[i], p1_disjoint[i])
 --        ^
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_num_affine2.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_num_affine2.rg
@@ -12,8 +12,11 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
+-- runs-with:
+-- [["-findex-launch-dynamic", "0"]]
+
 -- fails-with:
--- optimize_index_launch_num_affine2.rg:37: loop optimization failed: argument 2 interferes with argument 1
+-- optimize_index_launch_num_affine2.rg:40: loop optimization failed: argument 2 interferes with argument 1
 --     g2(p[i], p[i+1])
 --       ^
 

--- a/language/tests/regent/compile_fail/optimize_index_launch_projection1.rg
+++ b/language/tests/regent/compile_fail/optimize_index_launch_projection1.rg
@@ -13,7 +13,7 @@
 -- limitations under the License.
 
 -- runs-with:
--- [["-fflow", "0"]]
+-- [["-fflow", "0", "-findex-launch-dynamic", "0"]]
 
 -- fails-with:
 -- optimize_index_launch_projection1.rg:46: loop optimization failed: argument 2 interferes with argument 1


### PR DESCRIPTION
This PR extends the work in #1054 by adding support for projection functor cross-checks, i.e., checking multiple arguments of the same partition but using different projection functors against each other. For `N` arguments of the same partition, the check takes `O(N)` time.

For example, the safety of the following index launch can now be dynamically checked:

```
__demand(__index_launch)
for i in ... do
  foo(p[i % a], p[i % b], p[i % c])
end
```
Additionally, this PR also adds support for analyzing projection functors of dimension up to 9.
