### PR TITLE
Added new error message when fspace type is undefined to the specialize.t file

### DIFF
--- a/language/src/regent/specialize.t
+++ b/language/src/regent/specialize.t
@@ -885,6 +885,9 @@ end
 function specialize.expr_region(cx, node, allow_lists)
   local ispace = specialize.expr(cx, node.ispace)
   local fspace_type = node.fspace_type_expr(cx.env:env())
+  if not fspace_type then
+    report.error(node, "fspace type is undefined or nil")
+  end
   return ast.specialized.expr.Region {
     ispace = ispace,
     fspace_type = fspace_type,

--- a/language/tests/regent/compile_fail/missing_fspace_type.rg
+++ b/language/tests/regent/compile_fail/missing_fspace_type.rg
@@ -1,0 +1,24 @@
+-- Copyright 2021 Stanford University
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+-- fails-with:
+-- missing_fspace_type.rg:22: fspace type is undefined or nil
+--   var r = region(ispace(int1d, 2), this_fs_does_not_exist)
+
+import "regent"
+
+task main()
+  var r = region(ispace(int1d, 2), this_fs_does_not_exist)
+end
+regentlib.start(main)


### PR DESCRIPTION
In the specialize.t expr_region call, added a check to ensure fspace_type exists, and if it is not throw a clean error.

 Added a new test file, missing_fspace_type.rg, to ensure this works.

Tested in all tests suites.