### PR TITLE
Allow `legion` build dir to be used as root for `find_package`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 #------------------------------------------------------------------------------#
 
 cmake_minimum_required(VERSION 3.7)
-project(Legion)
+project(Legion VERSION 22.05.00)
 
 #------------------------------------------------------------------------------#
 # Some boilerplate to setup nice output directories
@@ -383,7 +383,7 @@ if(Legion_USE_HIP)
     if(BUILD_SHARED_LIBS)
       set(HIPCC_FLAGS "${HIPCC_FLAGS} -fPIC")
     endif()
-    
+
     install(FILES ${Legion_SOURCE_DIR}/cmake/FindHIP.cmake
       DESTINATION ${CMAKE_INSTALL_DATADIR}/Legion/cmake
     )
@@ -702,6 +702,8 @@ endforeach()
 #------------------------------------------------------------------------------#
 # Build-tree package generation
 #------------------------------------------------------------------------------#
+include(CMakePackageConfigHelpers)
+
 export(EXPORT LegionTargets
   NAMESPACE Legion::
   FILE ${Legion_BINARY_DIR}/LegionTargets.cmake
@@ -726,6 +728,11 @@ configure_file(
   ${Legion_BINARY_DIR}/LegionConfig.cmake
   @ONLY
 )
+
+write_basic_package_version_file(
+  ${Legion_BINARY_DIR}/LegionConfig-version.cmake
+  VERSION ${Legion_VERSION}
+  COMPATIBILITY ExactVersion)
 
 install(FILES cmake/LegionConfig-install.cmake
   DESTINATION ${CMAKE_INSTALL_DATADIR}/Legion/cmake

--- a/bindings/regent/CMakeLists.txt
+++ b/bindings/regent/CMakeLists.txt
@@ -53,6 +53,7 @@ if(Legion_USE_CUDA)
 else()
   add_library(Regent ${REGENT_SRC})
 endif()
+add_library(Legion::Regent ALIAS Regent)
 target_link_libraries(Regent Legion::Legion)
 
 if(Legion_USE_CUDA)

--- a/cmake/FindLLVM.cmake
+++ b/cmake/FindLLVM.cmake
@@ -54,10 +54,10 @@ if(NOT LLVM_FOUND AND NOT TARGET_LLVM)
     if(${LLVM_VERSION} VERSION_GREATER 3.5.99)
       list(REMOVE_ITEM LLVM_FIND_COMPONENTS jit)
     endif()
-    foreach(C IN LISTS LLVM_FIND_COMPONENTS)
-      list(FIND LLVM_AVAILABLE_COMPONENTS ${C} C_IDX)
+    foreach(_component IN LISTS LLVM_FIND_COMPONENTS)
+      list(FIND LLVM_AVAILABLE_COMPONENTS ${_component} C_IDX)
       if(C_IDX EQUAL -1)
-        message(FATAL_ERROR "${C} is not an available component for LLVM found at ${LLVM_CONFIG_EXECUTABLE}")
+        message(FATAL_ERROR "${_component} is not an available component for LLVM found at ${LLVM_CONFIG_EXECUTABLE}")
       endif()
     endforeach()
 
@@ -67,7 +67,7 @@ if(NOT LLVM_FOUND AND NOT TARGET_LLVM)
       OUTPUT_VARIABLE _LLVM_LIBS
       OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET
     )
-    # some versions of LLVM have a bug with libfiles where they produce 
+    # some versions of LLVM have a bug with libfiles where they produce
     #  /path/to/liblibfoo.so.so - do some string replaces to fix this
     string(REPLACE "liblib" "lib" _LLVM_LIBS ${_LLVM_LIBS})
     string(REPLACE ".so.so" ".so" _LLVM_LIBS ${_LLVM_LIBS})

--- a/cmake/LegionConfig-build.cmake.in
+++ b/cmake/LegionConfig-build.cmake.in
@@ -1,2 +1,8 @@
 list(INSERT CMAKE_MODULE_PATH 0 @Legion_SOURCE_DIR@/cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/LegionConfigCommon.cmake)
+
+# Set our version variables
+set(Legion_VERSION_MAJOR @Legion_VERSION_MAJOR@)
+set(Legion_VERSION_MINOR @Legion_VERSION_MINOR@)
+set(Legion_VERSION_PATCH @Legion_VERSION_PATCH@)
+set(Legion_VERSION @Legion_VERSION@)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -39,7 +39,7 @@ list(APPEND REALM_SRC
   realm/deppart/inst_helper.h
   realm/deppart/partitions.h               realm/deppart/partitions.cc
   realm/deppart/preimage.h
-  realm/deppart/rectlist.h                 
+  realm/deppart/rectlist.h
   realm/deppart/rectlist.inl
   realm/deppart/setops.h                   realm/deppart/setops.cc
   realm/deppart/sparsity_impl.h            realm/deppart/sparsity_impl.cc
@@ -230,6 +230,7 @@ endforeach()
 find_package(Threads REQUIRED)
 cmake_policy(SET CMP0063 NEW) # visibility controls in all builds
 add_library(RealmRuntime ${REALM_SRC})
+add_library(Legion::RealmRuntime ALIAS RealmRuntime)
 target_compile_options(RealmRuntime PRIVATE ${CXX_BUILD_WARNING_FLAGS})
 
 # turn on warnings about partially-overloaded methods, if supported
@@ -432,7 +433,7 @@ if(Legion_USE_CUDA)
       # without Kokkos interop, we can just add the hijack directly
       target_sources(RealmRuntime PRIVATE realm/cuda/cudart_hijack.cc)
     endif()
-    
+
     # filter anything referring to *cudart* out of the CUDA_LIBRARIES
     #  making sure our changes are visible to the scope above
     # so list(FILTER ...) doesn't exist until cmake 3.6 - do string regex instead
@@ -464,7 +465,7 @@ if(Legion_USE_HIP)
     target_link_libraries(RealmRuntime PRIVATE ${CUDA_CUDA_LIBRARY})
     # for backwards compatibility in applications
     target_compile_definitions(RealmRuntime INTERFACE USE_HIP)
-  
+
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D__HIP_PLATFORM_NVCC__")
   endif()
 
@@ -572,7 +573,7 @@ if(Legion_USE_Kokkos)
   # and add kokkos libraries to our exported library requirements
   set_property(TARGET RealmRuntime APPEND
     PROPERTY INTERFACE_LINK_LIBRARIES "\$<LINK_ONLY:Kokkos::kokkoscore>")
-  
+
   # if Kokkos' CUDA target is enabled, and we're performing runtime hijack,
   #  rewrite Kokkos' cudart dependency to be on Realm instead
   if(Kokkos_ENABLE_CUDA AND Legion_HIJACK_CUDART)
@@ -639,16 +640,16 @@ list(APPEND LEGION_SRC
   legion/bitmask.h
   legion/field_tree.h
   legion/garbage_collection.h             legion/garbage_collection.cc
-  legion/interval_tree.h                 
-  legion/legion_allocation.h             
+  legion/interval_tree.h
+  legion/legion_allocation.h
   legion/legion_analysis.h                legion/legion_analysis.cc
   legion/legion_c.h                       legion/legion_c.cc
-  legion/legion_config.h                 
+  legion/legion_config.h
   legion/legion_constraint.h              legion/legion_constraint.cc
   legion/legion_context.h                 legion/legion_context.cc
-  legion/legion_c_util.h                 
+  legion/legion_c_util.h
   legion/legion.cc
-  legion/legion.inl                      
+  legion/legion.inl
   legion/legion_domain.h
   legion/legion_domain.inl
   legion/legion_instances.h               legion/legion_instances.cc
@@ -659,12 +660,12 @@ list(APPEND LEGION_SRC
   legion/legion_spy.h                     legion/legion_spy.cc
   legion/legion_tasks.h                   legion/legion_tasks.cc
   legion/legion_trace.h                   legion/legion_trace.cc
-  legion/legion_types.h                 
-  legion/legion_utilities.h             
+  legion/legion_types.h
+  legion/legion_utilities.h
   legion/legion_views.h                   legion/legion_views.cc
   legion/legion_redop.h                   legion/legion_redop.cc
   legion/mapper_manager.h                 legion/mapper_manager.cc
-  legion/rectangle_set.h                
+  legion/rectangle_set.h
   legion/region_tree.h                    legion/region_tree.cc
   legion/runtime.h                        legion/runtime.cc
 )
@@ -707,22 +708,22 @@ foreach(INST_N1 RANGE 1 ${LEGION_MAX_DIM})
   set(SRCFILE legion/region_tree)
   configure_file(${PROJECT_SOURCE_DIR}/cmake/deppart_tmpl.cc.in ${SRCFILE}_${INST_N1}.cc)
   list(APPEND LEGION_SRC ${SRCFILE}_${INST_N1}.cc)
-  
+
   foreach(INST_N2 RANGE 1 ${LEGION_MAX_DIM})
     configure_file(${PROJECT_SOURCE_DIR}/cmake/deppart_tmpl.cc.in ${SRCFILE}_${INST_N1}_${INST_N2}.cc)
     list(APPEND LEGION_SRC ${SRCFILE}_${INST_N1}_${INST_N2}.cc)
   endforeach()
   unset(SRCFILE)
 endforeach()
-              
+
 # Legion Fortran
 if(Legion_USE_Fortran)
   list(APPEND LEGION_FORTRAN_SRC
     legion/legion_f_types.f90
     legion/legion_f_c_interface.f90
-    legion/legion_f.f90              
+    legion/legion_f.f90
   )
-endif()               
+endif()
 
 # HACK: completely separating the Legion and Realm cmake stuff will take
 #  a while, so just exclude LegionRuntime from the "all" target for the
@@ -732,6 +733,7 @@ if(Legion_BUILD_REALM_ONLY)
 endif()
 
 add_library(LegionRuntime ${EXCLUDE_LEGION} ${MAPPER_SRC} ${LEGION_SRC} ${LEGION_FORTRAN_SRC})
+add_library(Legion::LegionRuntime ALIAS LegionRuntime)
 # do we have any cuda source files in Legion itself?
 if(LEGION_CUDA_SRC)
   if("${Legion_CUDA_ARCH}" STREQUAL "")


### PR DESCRIPTION
This PR allows downstream projects to use the legion build directory as a package root for CMake's `find_package`:

```shell
# CMakeLists.txt
# project(test LANGUAGES C CXX CUDA)
# find_package(Legion 22.05)

# Configure CMakeLists.txt and use an existing legion build directory
cmake -S . -B build -D Legion_ROOT=/path/to/legion/build
```

This makes it easier to develop Legion in parallel with other projects like [`legate.core`](https://github.com/nv-legate/legate.core) and [`cuNumeric`](https://github.com/nv-legate/cunumeric), as it avoids the need to install Legion in order for a dependent project to use it.

Summary of changes:
* Add project version
* Generate `LegionConfig-version.cmake`
* Write project version variables to generated `LegionConfig.cmake`
* Define library aliases so they mirror the targets generated in `LegionTargets.cmake`
* Rename `C` component in `FindLLVM.cmake` to avoid overwriting value of global `C` CMake variable (alternative to turning on cmake policy `CMP0124`)

