### PR TITLE
Add OMP_PROC and PY_PROC cases for Realm Processor get_kind_name

### DIFF
--- a/runtime/realm/proc_impl.cc
+++ b/runtime/realm/proc_impl.cc
@@ -371,6 +371,10 @@ namespace Realm {
           return "PROC_GROUP";
         case PROC_SET:
           return "PROC_SET";
+        case OMP_PROC:
+          return "OMP_PROC";
+        case PY_PROC:
+          return "PY_PROC";
         default:
           assert(0);
       }


### PR DESCRIPTION
Just came across these missing cases when I was playing around with the Realm OpenMP module. I checked and didn't find any, but please advise if there are any tests that should also be changed to cover these additions.