### PR TITLE
the default constructor should zero-initialize the members of `realm::Point`

### DIFF
--- a/runtime/realm/point.h
+++ b/runtime/realm/point.h
@@ -59,7 +59,7 @@ namespace Realm {
     T x, y, z, w;  T rest[N - 4];
 
     REALM_CUDA_HD
-    Point(void);
+    Point(void) = default;
     REALM_CUDA_HD
     explicit Point(T val);
     // construct from any integral value

--- a/runtime/realm/point.inl
+++ b/runtime/realm/point.inl
@@ -31,11 +31,6 @@ namespace Realm {
 
   template <int N, typename T>
   REALM_CUDA_HD
-  inline Point<N,T>::Point(void)
-  {}
-
-  template <int N, typename T>
-  REALM_CUDA_HD
   inline Point<N,T>::Point(T val)
   {
     for(int i = 0; i < N; i++)


### PR DESCRIPTION
At present, code such as the following:

```c++
realm::Point<2> p {};
```

will have uninitialized data members. This is surprising since the same syntax used on integers will zero-initialize them.

```c++
int i {};
assert( i == 0 );
```

By marking `Point`'s default constructor with `= default`, we make `Point` behave as the integers do with respect to default initialization.

Note that a `Point` _without_ an initilizer will still be uninitialized:

```c++
Point<2> p;
// WARNING: p.x and p.y are uninitialized here!
```